### PR TITLE
Fix svelte package name

### DIFF
--- a/site/docs/docs/setup.md
+++ b/site/docs/docs/setup.md
@@ -46,7 +46,7 @@ For example, to install the `agnostic-react` package you'd do:
 npm install agnostic-react # or yarn add agostic-react
 ```
 
-_The currently available framework packages are: `agnostic-react`, `agnostic-vue`, `agnostic-angular`, and `angular-svelte`._
+_The currently available framework packages are: `agnostic-react`, `agnostic-vue`, `agnostic-angular`, and `agnostic-svelte`._
 
 <div class="mbe16"></div>
 


### PR DESCRIPTION
# Fix svelte package name in documentation

## Description

`angular-svelte` -> `agnostic-svelte`

## Checklist:

- [x] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)
