### PR TITLE
Update setup docs to explain usage in svelte

### DIFF
--- a/site/docs/docs/setup.md
+++ b/site/docs/docs/setup.md
@@ -215,7 +215,7 @@ To use the `agnostic-svelte` package in your project do the following:
 
 ```html
 <script>
-import 'agnostic-svelte/dist/common.min.css';
+import 'agnostic-svelte/css/common.min.css';
 // ...
 </script>
 ```


### PR DESCRIPTION
SvelteKit gives the error `Missing "./dist/common.min.css" export in "agnostic-svelte" package` when trying to import from /dist. Changing to /css seems to work. Not sure if I found a bug or if the docs are just out of date.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes (I didn't find an issue for this)

## Checklist:

Please delete options that are not relevant.

- [x] Is this a bug fix - maybe?
- [x] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)

_We realize above checklist is pretty intimidating, reach out with an at mention on your issue if you're interested in contributing but need some clarifications!_
