### PR TITLE
Dialog: Added required base layout updates

### DIFF
--- a/site/docs/docs/components/dialog.md
+++ b/site/docs/docs/components/dialog.md
@@ -416,6 +416,18 @@ Angular: [component source](https://github.com/AgnosticUI/agnosticui/blob/master
 
 **Please consider Svelte Dialog experimental and not yet ready for production until we can add [missing tests](https://github.com/AgnosticUI/svelte-a11y-dialog/issues/1)** — tl;dr is we'd like to write tests utilizing Cypress's component testing framework but we need to await an upcoming Vite + Cypress plugins to do so.
 
+In your main `app.html`, add a container where your dialog will be rendered into — `dialog-root` in this example:
+
+```html
+<!DOCTYPE html>
+<html>
+  <body>
+		<div id="svelte">%svelte.body%</div>
+    <div id="dialog-root"></div>
+  </body>
+</html>
+```
+
 <div class="mbe16"></div>
 
 ```html


### PR DESCRIPTION
Not sure if this is too sveltekit specific, but the dialog components needs a `#dialog-root` somewhere to append to. I added some information to the svelte section that refers to `app.html`. See https://www.npmjs.com/package/svelte-a11y-dialog

Fixes # (no issue for this)

## Checklist:

Please delete options that are not relevant.

- [x] Is this a bug fix - kinda
- [x] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)

_We realize above checklist is pretty intimidating, reach out with an at mention on your issue if you're interested in contributing but need some clarifications!_
