### PR TITLE
broken link in docs

### DIFF
--- a/site/docs/docs/theming.md
+++ b/site/docs/docs/theming.md
@@ -109,7 +109,7 @@ AgnosticUI uses a particular _focus ring_ which is defined in [focus design toke
 
 ### Reset
 
-AgnosticUI's `common.min.css` contains a small [reset](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-css/public/css-src/reset.css#L1). If you'd prefer, you can alternatively import the reset as an individual module from [agnostic-css/public/css-dist/common.resets.min.css](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-css/public/css-dist/common.resets.min.csss)
+AgnosticUI's `common.min.css` contains a small [reset](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-css/public/css-src/resets/reset.css#L1). If you'd prefer, you can alternatively import the reset as an individual module from [agnostic-css/public/css-dist/common.resets.min.css](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-css/public/css-dist/common.resets.min.csss)
 
 ### Other Tokens
 


### PR DESCRIPTION
# Pull Request Template

## Description

I noticed a broken link in the docs

## Checklist:
- [x] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)
