### PR TITLE
Provide two-way data binding on Inputs, ChoiceInput (checkbox/radio), Select, and Switch

### DIFF
--- a/agnostic-svelte/package_test/package-lock.json
+++ b/agnostic-svelte/package_test/package-lock.json
@@ -8,7 +8,7 @@
       "name": "package_test",
       "version": "0.0.0",
       "dependencies": {
-        "agnostic-svelte": "file:../agnostic-svelte-1.1.15.tgz"
+        "agnostic-svelte": "file:../agnostic-svelte-1.1.17.tgz"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
@@ -69,9 +69,9 @@
       "integrity": "sha512-BizdxC9SYdd0kgY/3lcDeeiSTs4BwUsa0oc5Nsaz5j397rZgC0vO1Tlvj5XOk/1pqTtnBi0ptu0/6CQvdwnsww=="
     },
     "node_modules/agnostic-svelte": {
-      "version": "1.1.15",
-      "resolved": "file:../agnostic-svelte-1.1.15.tgz",
-      "integrity": "sha512-ojoW/f4fgoGXEUVLIwaEwxDsZnk9buij5ys4lIBGX3LOWHyma+4gLq4Th3Z0OQ4ehvGiwgy3xXZ390dgbLtFxg==",
+      "version": "1.1.17",
+      "resolved": "file:../agnostic-svelte-1.1.17.tgz",
+      "integrity": "sha512-xLEU3ncmseGOKdXRUV/Uevns6llwqCuP4FDjYtXOozPFxzZmajFV02ieI1gZC9gJ+bLsaSNrbHZK5Jkv8+ilLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "agnostic-helpers": "^1.0.2",
@@ -641,8 +641,8 @@
       "integrity": "sha512-BizdxC9SYdd0kgY/3lcDeeiSTs4BwUsa0oc5Nsaz5j397rZgC0vO1Tlvj5XOk/1pqTtnBi0ptu0/6CQvdwnsww=="
     },
     "agnostic-svelte": {
-      "version": "file:../agnostic-svelte-1.1.15.tgz",
-      "integrity": "sha512-ojoW/f4fgoGXEUVLIwaEwxDsZnk9buij5ys4lIBGX3LOWHyma+4gLq4Th3Z0OQ4ehvGiwgy3xXZ390dgbLtFxg==",
+      "version": "file:../agnostic-svelte-1.1.17.tgz",
+      "integrity": "sha512-xLEU3ncmseGOKdXRUV/Uevns6llwqCuP4FDjYtXOozPFxzZmajFV02ieI1gZC9gJ+bLsaSNrbHZK5Jkv8+ilLw==",
       "requires": {
         "agnostic-helpers": "^1.0.2",
         "svelte-a11y-dialog": "^0.2.0"

--- a/agnostic-svelte/package_test/package-lock.json
+++ b/agnostic-svelte/package_test/package-lock.json
@@ -71,7 +71,7 @@
     "node_modules/agnostic-svelte": {
       "version": "1.1.17",
       "resolved": "file:../agnostic-svelte-1.1.17.tgz",
-      "integrity": "sha512-xLEU3ncmseGOKdXRUV/Uevns6llwqCuP4FDjYtXOozPFxzZmajFV02ieI1gZC9gJ+bLsaSNrbHZK5Jkv8+ilLw==",
+      "integrity": "sha512-9ec2MlGVnMTIufn28oY+Zu2U0XdpQK2w0bQWEJo4dQD86O0NXiegPcBHhYW/cj2fMzcDL/OOPlSvzcgihdH6Dg==",
       "license": "Apache-2.0",
       "dependencies": {
         "agnostic-helpers": "^1.0.2",
@@ -642,7 +642,7 @@
     },
     "agnostic-svelte": {
       "version": "file:../agnostic-svelte-1.1.17.tgz",
-      "integrity": "sha512-xLEU3ncmseGOKdXRUV/Uevns6llwqCuP4FDjYtXOozPFxzZmajFV02ieI1gZC9gJ+bLsaSNrbHZK5Jkv8+ilLw==",
+      "integrity": "sha512-9ec2MlGVnMTIufn28oY+Zu2U0XdpQK2w0bQWEJo4dQD86O0NXiegPcBHhYW/cj2fMzcDL/OOPlSvzcgihdH6Dg==",
       "requires": {
         "agnostic-helpers": "^1.0.2",
         "svelte-a11y-dialog": "^0.2.0"

--- a/agnostic-svelte/package_test/package.json
+++ b/agnostic-svelte/package_test/package.json
@@ -13,6 +13,6 @@
     "vite": "^2.7.2"
   },
   "dependencies": {
-    "agnostic-svelte": "file:../agnostic-svelte-1.1.15.tgz"
+    "agnostic-svelte": "file:../agnostic-svelte-1.1.17.tgz"
   }
 }

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -524,7 +524,7 @@
       </div>
     </Input>
     <div><code>bind:value</code> when using textarea: {textareaValueText}</div> 
-    <Input type='textarea' bind:value={textareaValueText}></Input>
+    <Input type='textarea' bind:value={textareaValueText} placeholder="Textarea works with bind:value too!"></Input>
   </Card>
   <Card>
     <h2>Checkbox</h2>

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -308,6 +308,9 @@
   let testIsInvalid = false;
   let testHelpText = false;
 
+  // These are used to verify bind:value refactor for Input component
+  let valueText = '';
+  let addonValueText = '';
 </script>
 
 <main class="container">
@@ -470,7 +473,9 @@
     <Button isDisabled={isButtonDisabled}>Disabled</Button>
   </div>
   <Card>
-    <h2>Input</h2>
+    <div class="h4 w-100">Input</div>
+    <div><code>bind:value</code> test: {valueText}</div>
+    <Input bind:value={valueText} placeholder="type in here to verify bind:value" />
     <Input id="1" label="Default input" />
     <Input id="2" isRounded label="Rounded input" />
     <Input id="3" isUnderlined label="Underlined input" />
@@ -482,7 +487,10 @@
     <Input id="8" helpText={testHelpText ? 'Some useful help hint…' : null} label="Help text" />
     <button class="mie32" on:click={() => testIsInvalid=!testIsInvalid}>Toggle is invalid</button>
     <Input id="9" isInvalid={testIsInvalid} invalidText="Some error hint…" label="Error hints" />
+    <div><code>bind:value</code> when using input addons: {addonValueText}</div>
     <Input
+      bind:value={addonValueText}
+      placeholder="type in here to verify bind:value"
       hasLeftAddon={true}
       hasRightAddon={true}
       id="10"

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -311,6 +311,7 @@
   // These are used to verify bind:value refactor for Input component
   let valueText = '';
   let addonValueText = '';
+  let textareaValueText = '';
 </script>
 
 <main class="container">
@@ -507,7 +508,6 @@
     <Input
       hasRightAddon={true}
       id="bug114"
-      bind:value
       type={textIsVisible ? 'text' : 'password'}
       label="Password input toggle (visible / invisible)"
     >
@@ -523,6 +523,8 @@
         </InputAddonItem>
       </div>
     </Input>
+    <div><code>bind:value</code> when using textarea: {textareaValueText}</div> 
+    <Input type='textarea' bind:value={textareaValueText}></Input>
   </Card>
   <Card>
     <h2>Checkbox</h2>

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -312,6 +312,7 @@
   let valueText = '';
   let addonValueText = '';
   let textareaValueText = '';
+  let checkedValue = false;
 </script>
 
 <main class="container">
@@ -559,7 +560,8 @@
   </Card>
   <section class="mbs32 mbe24">
     <h2>Switch</h2>
-    <Switch id="switch-1" label="Switch default" />
+    <div><code>bind:isChecked</code> test: {checkedValue}</div>
+    <Switch id="switch-1" label="Switch—use bind:isChecked" bind:isChecked={checkedValue} />
     <Switch id="switch-small" size="small" label="Switch small" />
     <Switch id="switch-lg" size="large" label="Switch large" />
     <Switch

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -288,7 +288,7 @@
 			label: "Monthly",
 		},
 	];
-  const optionNames = ['frequency', 'schedule', 'howoften', 'when', 'letmeknow', 'whenz']
+  const optionNames = ['frequency', 'schedule', 'howoften', 'when', 'letmeknow', 'whenz', 'times']
   const options = []
   for (let i = 0; i < optionNames.length; i += 1) {
     const optionName = optionNames[i];
@@ -312,6 +312,8 @@
   let valueText = '';
   let addonValueText = '';
   let textareaValueText = '';
+  let choiceCheckboxesValue;
+  let choiceRadioValue;
   let checkedValue = false;
   let selectedValue;
   let multiSelectValue;
@@ -530,8 +532,11 @@
     <Input type='textarea' bind:value={textareaValueText} placeholder="Textarea works with bind:value too!"></Input>
   </Card>
   <Card>
-    <h2>Checkbox</h2>
-    <ChoiceInput id={options[0][0].name} type="checkbox" isInline options={options[0]} />
+    <div class="h4 w-100">Checkbox</div>
+    <div class="block w-100 mbs24 mbe16">
+      <div class="mbe16"><code>bind:checked</code> when using checkbox: {choiceCheckboxesValue }</div> 
+      <ChoiceInput isFieldset={false} id={options[0][0].name} type="checkbox" isInline options={options[0]} bind:checked={choiceCheckboxesValue} />
+    </div>
     <ChoiceInput id={options[1][0].name} type="checkbox" isInline isDisabled options={options[1]} />
     <h2>Weekly disabled only</h2>
     <ChoiceInput id={options[2][0].name} type="checkbox" isInline disabledOptions={["weekly"]} options={options[2]} />
@@ -542,6 +547,10 @@
     <ChoiceInput id={options[4][0].name} type="radio" isInline isDisabled options={options[4]} />
     <Button css="mie32" on:click={() => testIsInvalid=!testIsInvalid}>Toggle is invalid</Button>
     <ChoiceInput id={options[5][0].name} type="radio" isInvalid={testIsInvalid} options={options[5]} />
+    <div class="block w-100 mbs24 mbe16">
+      <div class="mbe16"><code>bind:checked</code> when using radios: { choiceRadioValue }</div> 
+      <ChoiceInput isFieldset={false} id={options[6][0].name} type="radio" isInline options={options[6]} bind:checked={choiceRadioValue} />
+    </div>
   </Card>
   <Card>
     <div class="mbs40">
@@ -1147,9 +1156,9 @@
         on:selected={(e) => {
           console.log('Multi select: ', e.detail);
         }}
-        unique-id="sel6"
+        uniqueId="sel6"
         name="select6"
-        label-copy="Select the best tennis player of all time"
+        labelCopy="Select the best tennis player of all time"
       />
     </div>
   </section>

--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -313,6 +313,8 @@
   let addonValueText = '';
   let textareaValueText = '';
   let checkedValue = false;
+  let selectedValue;
+  let multiSelectValue;
 </script>
 
 <main class="container">
@@ -1088,7 +1090,9 @@
   </Card>
   <section class="mbs32 mbe24">
     <h2>Select default</h2>
+    <div class="mbe16"><code>bind:selected</code> test: {selectedValue}</div>
     <Select
+      bind:selected={selectedValue}
       uniqueId="sel1"
       name="select1"
       labelCopy="Select the best tennis player of all time"
@@ -1134,7 +1138,9 @@
     />
     <h2>Multiple select size 4</h2>
     <div class="mbs12 mbe16">
+      <div class="mbe16"><code>bind:multiSelected</code> test: {multiSelectValue}</div>
       <Select
+        bind:multiSelected={multiSelectValue}
         isMultiple
         multipleSize={4}
         options={tennisOptions}

--- a/agnostic-svelte/src/lib/components/ChoiceInput/ChoiceInput.svelte
+++ b/agnostic-svelte/src/lib/components/ChoiceInput/ChoiceInput.svelte
@@ -265,6 +265,9 @@ itself. */
   export let legendLabel = type || "choice input";
   export let size = "";
 
+  // Provides bind:checked capabilities that consumer can use
+  export let checked = [];
+
   $: labelClasses = [
     type ? `${type}-label-wrap` : "",
     isInline ? `${type}-label-wrap-inline` : "",
@@ -338,7 +341,15 @@ itself. */
         disabled={isDisabled || disabledOptions.includes(value)}
         checked={checkedOptions.includes(value)}
         on:blur
-        on:change
+        on:change={(e) => {
+          // This allows the consumer to use bind:checked={checkedValues} idiom.
+          // We cannot use the bind:group idiom as we're using dynamic type above,
+          // So, essentially, we're manually implementing two-way binding here ;-)
+          checked =
+            Array.from(document.getElementsByName(e.target.name))
+              .filter(el => el.checked)
+              .map(el => el.value);
+        }}
         on:input
         on:click
         on:focus

--- a/agnostic-svelte/src/lib/components/Input/Input.svelte
+++ b/agnostic-svelte/src/lib/components/Input/Input.svelte
@@ -370,31 +370,17 @@ borders that visually conflict. */
   };
   
   $: addonContainerClasses = () => "input-addon-container";
-
-  $: updateType = (node) => {
-    console.log('updateType: ', inputType)
-    node.type = inputType;
-  }
-  /*
-      <input
-      id={id}
-      use:updateType
-      bind:value
-      class={inputClasses}
-      disabled={isDisabled}
-      on:blur
-      on:change*/
 </script>
 <div class="w-100">
   <label class={labelClasses} for={id}>{label}</label>
   {#if type == "textarea"}
     <textarea
       id={id}
-      bind:value
       class={inputClasses}
       on:blur
       on:change
-      on:input
+      value={value}
+      on:input={e => value = e.target.value}
       on:click
       on:focus
       {...$$restProps}></textarea>

--- a/agnostic-svelte/src/lib/components/Input/Input.svelte
+++ b/agnostic-svelte/src/lib/components/Input/Input.svelte
@@ -371,6 +371,10 @@ borders that visually conflict. */
   
   $: addonContainerClasses = () => "input-addon-container";
 
+  $: updateType = (node) => {
+    console.log('updateType: ', inputType)
+    node.type = inputType;
+  }
 </script>
 <div class="w-100">
   <label class={labelClasses} for={id}>{label}</label>
@@ -390,8 +394,8 @@ borders that visually conflict. */
       <slot name="addonLeft" />
       <input
         id={id}
-        value={value}
-        type={inputType}
+        use:updateType
+        bind:value
         class={inputClasses}
         disabled={isDisabled}
         on:blur
@@ -406,8 +410,8 @@ borders that visually conflict. */
   {:else}
     <input
       id={id}
-      type={inputType}
-      value={value}
+      use:updateType
+      bind:value
       class={inputClasses}
       disabled={isDisabled}
       on:blur

--- a/agnostic-svelte/src/lib/components/Input/Input.svelte
+++ b/agnostic-svelte/src/lib/components/Input/Input.svelte
@@ -379,8 +379,7 @@ borders that visually conflict. */
       class={inputClasses}
       on:blur
       on:change
-      value={value}
-      on:input={e => value = e.target.value}
+      bind:value
       on:click
       on:focus
       {...$$restProps}></textarea>

--- a/agnostic-svelte/src/lib/components/Input/Input.svelte
+++ b/agnostic-svelte/src/lib/components/Input/Input.svelte
@@ -375,6 +375,15 @@ borders that visually conflict. */
     console.log('updateType: ', inputType)
     node.type = inputType;
   }
+  /*
+      <input
+      id={id}
+      use:updateType
+      bind:value
+      class={inputClasses}
+      disabled={isDisabled}
+      on:blur
+      on:change*/
 </script>
 <div class="w-100">
   <label class={labelClasses} for={id}>{label}</label>
@@ -394,13 +403,13 @@ borders that visually conflict. */
       <slot name="addonLeft" />
       <input
         id={id}
-        use:updateType
-        bind:value
+        type={inputType}
+        value={value}
         class={inputClasses}
         disabled={isDisabled}
         on:blur
         on:change
-        on:input
+        on:input={e => value = e.target.value}
         on:click
         on:focus
         {...$$restProps}
@@ -410,13 +419,13 @@ borders that visually conflict. */
   {:else}
     <input
       id={id}
-      use:updateType
-      bind:value
+      type={inputType}
+      value={value}
       class={inputClasses}
       disabled={isDisabled}
       on:blur
       on:change
-      on:input
+      on:input={e => value = e.target.value}
       on:click
       on:focus
       {...$$restProps}

--- a/agnostic-svelte/src/lib/components/Select/Select.svelte
+++ b/agnostic-svelte/src/lib/components/Select/Select.svelte
@@ -95,11 +95,13 @@
   export let isSkinned = true;
   export let css = "";
 
-  let selected;
+  // selected can be used for two-way bindings
+  export let selected;
+
   // If we don't make it seems Svelte gets confused:
   // https://github.com/sveltejs/svelte/issues/5644
   // And so we cannot share selected above :(
-  let multiSelected = [];
+  export let multiSelected = [];
 
   const dispatch = createEventDispatcher();
   // This will emit an event object that has a event.detail prop

--- a/agnostic-svelte/src/lib/components/Switch/Switch.svelte
+++ b/agnostic-svelte/src/lib/components/Switch/Switch.svelte
@@ -263,7 +263,7 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled#:~:text=Th
     type="checkbox"
     class="switch-input"
     id={id}
-    checked={isChecked}
+    bind:checked={isChecked}
     disabled={isDisabled}
     on:change
     on:click={handleClick}

--- a/site/docs/docs/components/inputs.md
+++ b/site/docs/docs/components/inputs.md
@@ -407,9 +407,14 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
 <script>
   import 'agnostic-svelte/css/common.min.css';
   import { Input, InputAddonItem } from "agnostic-svelte";
+  let valueText = '';
+  let addonValueText = '';
+  let textareaValueText = '';
 </script>
 <section>
-  <h2>Input</h2>
+  <div class="h4 w-100">Input</div>
+  <div><code>bind:value</code> test: {valueText}</div>
+  <Input bind:value={valueText} placeholder="type in here to verify bind:value" />
   <Input uniqueId="1" label="Default input" />
   <Input uniqueId="2" isRounded label="Rounded input" />
   <Input uniqueId="3" isUnderlined label="Underlined input" />
@@ -419,7 +424,10 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
   <Input uniqueId="7" size="large" label="Large input" />
   <Input uniqueId="8" helpText="Some useful help hint…" label="Large input" />
   <Input uniqueId="9" isInvalid invalidText="Some error hint…" label="Large input" />
+  <div><code>bind:value</code> when using input addons: {addonValueText}</div>
   <Input
+    bind:value={addonValueText}
+    placeholder="type in here to verify bind:value"
     hasLeftAddon="{true}"
     hasRightAddon="{true}"
     id="10"
@@ -432,6 +440,27 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
       <InputAddonItem addonRight="{true}"><span>R</span></InputAddonItem>
     </div>
   </Input>
+  <p class="mbs24">Dynamic Input (#114)</p>
+  <Input
+    hasRightAddon={true}
+    id="bug114"
+    type={textIsVisible ? 'text' : 'password'}
+    label="Password input toggle (visible / invisible)"
+  >
+    <div slot="addonRight">
+      <InputAddonItem addonRight={true}>
+        <Button isBlank on:click={toggleTextVisibility}>
+          {#if textIsVisible}
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ion" width="1.125rem" height="1.125rem" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512" data-icon="ion:md-eye-off"><path d="M256.1 144.8c56.2 0 101.9 45.3 101.9 101.1 0 13.1-2.6 25.5-7.3 37l59.5 59c30.8-25.5 55-58.4 69.9-96-35.3-88.7-122.3-151.6-224.2-151.6-28.5 0-55.8 5.1-81.1 14.1l44 43.7c11.6-4.6 24.1-7.3 37.3-7.3zM52.4 89.7l46.5 46.1 9.4 9.3c-33.9 26-60.4 60.8-76.3 100.8 35.2 88.7 122.2 151.6 224.1 151.6 31.6 0 61.7-6.1 89.2-17l8.6 8.5 59.7 59 25.9-25.7L78.2 64 52.4 89.7zM165 201.4l31.6 31.3c-1 4.2-1.6 8.7-1.6 13.1 0 33.5 27.3 60.6 61.1 60.6 4.5 0 9-.6 13.2-1.6l31.6 31.3c-13.6 6.7-28.7 10.7-44.8 10.7-56.2 0-101.9-45.3-101.9-101.1 0-15.8 4.1-30.7 10.8-44.3zm87.8-15.7l64.2 63.7.4-3.2c0-33.5-27.3-60.6-61.1-60.6l-3.5.1z" fill="currentColor"></path></svg>
+          {:else}
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--ion" width="1.125rem" height="1.125rem" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512" data-icon="ion:md-eye"><path d="M256 105c-101.8 0-188.4 62.4-224 151 35.6 88.6 122.2 151 224 151s188.4-62.4 224-151c-35.6-88.6-122.2-151-224-151zm0 251.7c-56 0-101.8-45.3-101.8-100.7S200 155.3 256 155.3 357.8 200.6 357.8 256 312 356.7 256 356.7zm0-161.1c-33.6 0-61.1 27.2-61.1 60.4s27.5 60.4 61.1 60.4 61.1-27.2 61.1-60.4-27.5-60.4-61.1-60.4z" fill="currentColor"></path></svg>
+          {/if}
+        </Button>
+      </InputAddonItem>
+    </div>
+  </Input>
+  <div><code>bind:value</code> when using textarea: {textareaValueText}</div> 
+  <Input type='textarea' bind:value={textareaValueText} placeholder="Textarea works with bind:value too!"></Input>
 </section>
 ```
 </details>

--- a/site/docs/docs/components/select.md
+++ b/site/docs/docs/components/select.md
@@ -221,10 +221,14 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
 <script>
   import 'agnostic-svelte/css/common.min.css';
   import { Select } from "agnostic-svelte";
+  let selectedValue;
+  let multiSelectValue;
 </script>
 <section class="component-container">
   <h2>Select default</h2>
+  <div class="mbe16"><code>bind:selected</code> test: {selectedValue}</div>
   <Select
+    bind:selected={selectedValue}
     uniqueId="sel1"
     name="select1"
     labelCopy="Select the best tennis player of all time"
@@ -264,6 +268,20 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
     labelCopy="Select the best tennis player of all time"
     defaultOptionLabel="Select your favorite tennis player of all-time"
     options={tennisOptions}
+  />
+  <h2 class="mbs12 mbe16">Multiple select size 4</h2>
+  <div class="mbe16"><code>bind:multiSelected</code> test: {multiSelectValue}</div>
+  <Select
+    bind:multiSelected={multiSelectValue}
+    isMultiple
+    multipleSize={4}
+    options={tennisOptions}
+    on:selected={(e) => {
+      console.log('Multi select: ', e.detail);
+    }}
+    uniqueId="sel6"
+    name="select6"
+    labelCopy="Select the best tennis player of all time"
   />
 </section>
 ```

--- a/site/docs/docs/components/switch.md
+++ b/site/docs/docs/components/switch.md
@@ -13,6 +13,7 @@ The `Switch` component is best used to immediately toggle a single application i
 <script setup>
 import SwitchExamples from '../../components/SwitchExamples.vue'
 import { Alert } from "agnostic-vue";
+let checkedValue = false;
 </script>
 
 <div class="mbe32"></div>
@@ -213,6 +214,9 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
   import { Switch } from "agnostic-svelte";
 </script>
 <section>
+  <h2>Switch</h2>
+  <div><code>bind:isChecked</code> test: {checkedValue}</div>
+  <Switch id="switch-1" label="Switch—use bind:isChecked" bind:isChecked={checkedValue} />
   <Switch id="1" label="Switch default" />
   <Switch id="2" size="small" label="Switch small" />
   <Switch id="3" size="large" label="Switch large" />


### PR DESCRIPTION
For https://github.com/AgnosticUI/agnosticui/issues/147

@longrunningprocess I'll leave this here for a few hours in case you have a spare cycle to have a look. It's a large'ish PR so I'd recommend looking directly at [agnostic-svelte/package_test/src/App.svelte](https://github.com/AgnosticUI/agnosticui/pull/150/files#diff-f20d9256cc9e1f3267f44c304a04b6ede004724df67c20cf46279700179c2e3cR288) which shows the surface API from a consumer's usage standpoint. I think this makes things fairly idiomatic (although there are some places where the naming conventions have diverged; but I think it's fine personally).

Fwiw, I'm going to have to do all this for Vue `v-model` as well next :) Gotta make it idiomatic "principle of least surprise" and all that jazz