### PR TITLE
Make svelte pagination component less verbose

### DIFF
--- a/agnostic-svelte/package_test/src/App.svelte
+++ b/agnostic-svelte/package_test/src/App.svelte
@@ -206,17 +206,13 @@
   /**
    * Pagination
    */
-  const paging = usePagination({ offset: 1 });
   let currentPage = 1;
-  $: paginationPages = paging.generate(currentPage, 50);
+  
+  $: console.log("Current page changed", currentPage)
 
-  const onPageUpdated = async (pageNumber) => {
-    console.log("onPageUpdated called with page: ", pageNumber)
-    currentPage = pageNumber;
-  };
   
   const paginationArgs = {
-    onPageChange: onPageUpdated,
+    total: 50,
     navigationLabels: {
       previous: "Previa",
       next: "Siguiente",
@@ -1273,9 +1269,9 @@
     <section class="mbe24">
       <div class="h4 mbe24">Pagination (centered)</div>
       <!-- Most of the arguments to pagination component can be stuffed in a default
-        object like we have here in paginationArgs. But current and pages need to be
-        reactive so those should be passed in individually as you see here. -->
-      <Pagination {...paginationArgs} current={currentPage} pages={paginationPages} />
+        object like we have here in paginationArgs. But current needs to be bound to
+        send and receive updates, so it's passed in separately like you see here -->
+      <Pagination {...paginationArgs} bind:current={currentPage} />
     </section>
     <section class="mbe24">
       <div class="h4 mbe24">Menu</div>

--- a/agnostic-svelte/src/lib/components/Pagination/Pagination.svelte
+++ b/agnostic-svelte/src/lib/components/Pagination/Pagination.svelte
@@ -96,7 +96,7 @@
 </style>
 
 <script>
-  import { tick } from "svelte";
+  import { usePagination } from "agnostic-helpers/dist/index.esm";
 
   /**
    * Pagination component handles presentation only and does two things:
@@ -111,9 +111,11 @@
   // can be: 'start', 'center', 'end' (or empty string)
   export let justify = "";
   export let current = 1;
+  export let total = 1;
   export let pages = [];
+  export let pageGenerator = usePagination({ offset: 1 });
   export let ariaLabel = "pagination";
-  export let onPageChange;
+  // export let onPageChange; // made obsolete by bind:current
   export let isBordered = false;
   export let isFirstLast = true;
   export let navigationLabels = {
@@ -122,6 +124,15 @@
     previous: "Previous",
     next: "Next",
   };
+
+  function genPages(page) {
+    if (pageGenerator) {
+      pages = pageGenerator.generate(page, total);
+    }
+  }
+
+  $: genPages(current);
+
 
   // Note that in the template we've bound via bind:this -- essentially this is
   // like a react ref but in Svelte parlance it's a binding. This allows us to
@@ -171,13 +182,8 @@
     .join(" ");
 
   const handleClick = async (pageNumber) => {
-    if (onPageChange) {
-      onPageChange(pageNumber);
-    }
-    // In case the consumer's `onPageChange` is using reactivity to update the
-    // paging controls, we want to wait a tick here before focusing the current
-    // button reference aka binding (see https://svelte.dev/tutorial/tick)
-    await tick();
+    current = pageNumber;
+
     btn.focus();
   };
 </script>

--- a/agnostic-svelte/src/lib/components/Pagination/Pagination.svelte
+++ b/agnostic-svelte/src/lib/components/Pagination/Pagination.svelte
@@ -115,7 +115,6 @@
   export let pages = [];
   export let pageGenerator = usePagination({ offset: 1 });
   export let ariaLabel = "pagination";
-  // export let onPageChange; // made obsolete by bind:current
   export let isBordered = false;
   export let isFirstLast = true;
   export let navigationLabels = {

--- a/agnostic-svelte/src/lib/components/Pagination/PaginationExample.svelte
+++ b/agnostic-svelte/src/lib/components/Pagination/PaginationExample.svelte
@@ -17,35 +17,18 @@
     next: "Next",
   };
 
-  /**
-   * usePagination is basically responsible for generating the paging numbers
-   */
-  const paging = usePagination({ offset: offset });
-
-  // Internal state: currentPage is what dictates the regeneration of our paging
-  // controls. (e.g. when user clicks a new page—the paging controls update.)
-  let currentPage = current;
-
-  // Reactive declaration in Svelte is like useEffect in React in that it is triggered
-  // when a dependency changes.  Here, `currentPage` is that dependency.
-  $: paginationPages = paging.generate(currentPage, totalPages);
-
   // eslint-disable-next-line no-console
-  $: console.log(`currentPage updated to: ${currentPage}`);
+  $: console.log(`currentPage updated to: ${current}`);
 
-  const onPageUpdated = async (pageNumber) => {
-    if (onPageChange) {
-      onPageChange(pageNumber);
-    }
-    // Triggers reactive `paginationPages` update (since `current` is a dependency)
-    currentPage = pageNumber;
-  };
+  $: if (onPageChange) {
+    onPageChange(current);
+  }
 </script>
 
 <Pagination
-  current="{currentPage}"
-  pages="{paginationPages}"
-  onPageChange="{onPageUpdated}"
+  bind:current
+  total={totalPages}
+  pageGenerator={usePagination({ offset })}
   navigationLabels="{navigationLabels}"
   ariaLabel="{ariaLabel}"
   isBordered="{isBordered}"

--- a/site/docs/docs/components/pagination.md
+++ b/site/docs/docs/components/pagination.md
@@ -42,10 +42,10 @@ import { Alert } from "agnostic-vue";
 <summary class="disclose-title">View source</summary>
 
 ```jsx
-import { useEffect, useState } from 'react';
-import 'agnostic-react/dist/common.min.css';
-import 'agnostic-react/dist/esm/index.css';
-import { Pagination } from 'agnostic-react';
+import { useEffect, useState } from "react";
+import "agnostic-react/dist/common.min.css";
+import "agnostic-react/dist/esm/index.css";
+import { Pagination } from "agnostic-react";
 import { usePagination } from "agnostic-helpers/dist/index.esm";
 
 export const YourComponent = () => {
@@ -65,11 +65,17 @@ export const YourComponent = () => {
 
   return (
     <section className="mbe24">
-      <Pagination onPageChange={setPage} current={page} pages={pages} ariaLabel="Pagination to help navigate table" />
+      <Pagination
+        onPageChange={setPage}
+        current={page}
+        pages={pages}
+        ariaLabel="Pagination to help navigate table"
+      />
     </section>
-  )
+  );
 };
 ```
+
 </details>
 
 React: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-react/src/Pagination.tsx), [storybook tests](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-react/src/stories/Pagination.stories.tsx)
@@ -112,6 +118,7 @@ const interceptPageUpdate = (newPage) => {
   </section>
 </template>
 ```
+
 </details>
 
 Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-vue/src/components/Table.vue), [storybook tests](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-vue/src/stories/Table.stories.js)
@@ -129,28 +136,26 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
 
 ```html
 <script>
-  import 'agnostic-svelte/css/common.min.css';
+  import "agnostic-svelte/css/common.min.css";
   import { usePagination } from "agnostic-helpers/dist/index.esm";
   import { Pagination } from "agnostic-svelte";
 
   // Offset describes how many siblings besides current (must be 1 | 2)
   // Example of offset of 1: [1][2(current)][3]...[50]
   // Example of offset of 2: [1][2][3(current)][4][5]...[50]
-  const paging = usePagination({ offset: 1 });
+  // Pagination by default uses a generator with an offset of 1
+  // but we are including the use of a custom paging generator here as an example
+  const paging = usePagination({ offset: 2 });
 
-  // currentPage is the "dependency" that triggers reactive `paginationPages`
   let currentPage = 1;
-  $: paginationPages = paging.generate(currentPage, 50);
 
-  const onPageUpdated = async (pageNumber) => {
-    console.log("onPageUpdated called with page: ", pageNumber)
-    // This will trigger paginationPages to update itself above
-    currentPage = pageNumber;
-  };
-  
+  // Using $: here declares a reactive block, this code will run whenever
+  // currentPage is given a new value
+  $: console.log(`Current page is: ${currentPage}`);
+
   const paginationArgs = {
-    totalPages: 50,
-    onPageChange: onPageUpdated,
+    total: 50,
+    pageGenerator: paging,
     navigationLabels: {
       previous: "Previa",
       next: "Siguiente",
@@ -158,12 +163,15 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
       last: "Última",
     },
     ariaLabel: "Pagination",
-    justify: "center"
-  }
-
+    justify: "center",
+  };
 </script>
-<Pagination {...paginationArgs} current="{currentPage}" pages="{paginationPages}" />
+
+<!-- Using bind: here we establish a two way connection with the 'current' property -->
+<!-- meaning 'currentPage' will be updated whenever 'current' is updated internally -->
+<Pagination {...paginationArgs} bind:current="{currentPage}" />
 ```
+
 </details>
 
 Svelte: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-svelte/src/lib/components/Pagination/Pagination.svelte), [storybook tests](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-svelte/src/lib/components/Pagination/Pagination.stories.js)
@@ -259,6 +267,7 @@ export class YourComponent  implements OnInit {
   }
 }
 ```
+
 </details>
 
 Angular: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-angular/libs/ag/src/lib/pagination.component.ts), [storybook tests](https://github.com/AgnosticUI/agnosticui/blob/master/agnostic-angular/libs/ag/src/lib/pagination.component.stories.ts)

--- a/site/docs/docs/components/pagination.md
+++ b/site/docs/docs/components/pagination.md
@@ -42,11 +42,11 @@ import { Alert } from "agnostic-vue";
 <summary class="disclose-title">View source</summary>
 
 ```jsx
-import { useEffect, useState } from "react";
-import "agnostic-react/dist/common.min.css";
-import "agnostic-react/dist/esm/index.css";
-import { Pagination } from "agnostic-react";
-import { usePagination } from "agnostic-helpers/dist/index.esm";
+import { useEffect, useState } from 'react';
+import 'agnostic-react/dist/common.min.css';
+import 'agnostic-react/dist/esm/index.css';
+import { Pagination } from 'agnostic-react';
+import { usePagination } from 'agnostic-helpers/dist/index.esm';
 
 export const YourComponent = () => {
   const [page, setPage] = useState(1);


### PR DESCRIPTION
## Description

Leans into the Svelte framework specific features to make the Pagination component less verbose

Implements #171 

## Checklist:

Please delete options that are not relevant.

- [x] Is this a new feature
- [x] Have you submitted new feature or bugfix issue? Unless it's a small bugix, we generally prefer to track PRs against an issue which starts a dialogue to give us context.
- [x] Tests passing?
- [x] Have you added to the framework's /examples apps? e.g. `agnosticui-react/examples`? These are kitchen sink sanity checks which help to verify a component is working and derive documentation snippets.
- [x] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)
