### PR TITLE
Astro SignupForm Playground

### DIFF
--- a/integrations/agnosticui-astro/test/package-lock.json
+++ b/integrations/agnosticui-astro/test/package-lock.json
@@ -11,7 +11,7 @@
         "agnosticui-astro": "file:../agnosticui-astro-0.0.1.tgz"
       },
       "devDependencies": {
-        "astro": "^1.0.0-beta.19"
+        "astro": "^1.0.0-beta.20"
       }
     },
     "node_modules/@allmarkedup/fang": {
@@ -1332,9 +1332,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.19.tgz",
-      "integrity": "sha512-CXw4KDIAJdQG1ofDD+gDjp+Pb7yKjcU/bWm8+bDipRzlbZ8V2P0I3LScFd9eRgZ54Sz3AjEYR/WClT0n6aeJKg==",
+      "version": "1.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.20.tgz",
+      "integrity": "sha512-OlwM+NbBumAvVkksxCgQNRosxx5qVrFfbLTJsZfMTJ0eRgb34JiCTojHJ56NVLMquxgjBDDqk1OCYf2QbPeb5Q==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^0.14.2",
@@ -13909,9 +13909,9 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "astro": {
-      "version": "1.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.19.tgz",
-      "integrity": "sha512-CXw4KDIAJdQG1ofDD+gDjp+Pb7yKjcU/bWm8+bDipRzlbZ8V2P0I3LScFd9eRgZ54Sz3AjEYR/WClT0n6aeJKg==",
+      "version": "1.0.0-beta.20",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.20.tgz",
+      "integrity": "sha512-OlwM+NbBumAvVkksxCgQNRosxx5qVrFfbLTJsZfMTJ0eRgb34JiCTojHJ56NVLMquxgjBDDqk1OCYf2QbPeb5Q==",
       "dev": true,
       "requires": {
         "@astrojs/compiler": "^0.14.2",

--- a/integrations/agnosticui-astro/test/package.json
+++ b/integrations/agnosticui-astro/test/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview --experimental-integrations"
   },
   "devDependencies": {
-    "astro": "^1.0.0-beta.19"
+    "astro": "^1.0.0-beta.20"
   },
   "dependencies": {
     "agnosticui-astro": "file:../agnosticui-astro-0.0.1.tgz"

--- a/playgrounds/SignupForm/src/components/astro/AstroComponents.astro
+++ b/playgrounds/SignupForm/src/components/astro/AstroComponents.astro
@@ -3,16 +3,10 @@
   import AgInput from 'agnostic-astro/Input';
   import AgCard from 'agnostic-astro/Card';
   import AgChoiceInput from 'agnostic-astro/ChoiceInput';
-// TODO from INPUT
-  // onChange={handleChange}
-  // onBlur={() => handleBlur('usernameAstro')}
-  // isInvalid={result.hasErrors('usernameAstro')}
-  // invalidText={[...result.getErrors('usernameAstro')]}
-  let checked = [];
 
   const checkboxOptions = [{
-    name: "tosReact",
-    value: "tosReact",
+    name: "tosAstro",
+    value: "tosAstro",
     label: "I have read and agree to the terms of service."
   }];
 ---
@@ -36,8 +30,8 @@
       />
       <div class="mbs12"></div>
       <AgInput
-        id="pword-react"
-        name="passwordReact"
+        id="pword-astro"
+        name="passwordAstro"
         type="password"
         label="Password"
         autoComplete="new-password"
@@ -55,15 +49,101 @@
         id="agrees"
         type="checkbox"
         options={checkboxOptions}
-        checkedOptions={checked}
-        isFieldset={false}
-        legendLabel="agree to terms of service toggle"
+        checkedOptions={[]}
+        isFieldsetHidden={true}
+        legendLabel="Terms of service"
       />
       <div class="mbs32"></div>
-      <AgButton type="submit" mode="primary" isRounded isBlock>Submit</AgButton>
+      <AgButton id="submit" type="submit" mode="primary" isRounded isBlock disabled>Submit</AgButton>
     </form>
   </AgCard>
 </section>
+<script>
+  // TODO -- Need to add error hints
+  // isInvalid={result.hasErrors('usernameAstro')}
+  // invalidText={[...result.getErrors('usernameAstro')]}
+  import suite from "./suiteAstro";
+
+  let result = suite.get();
+  let formState = {};
+
+  let touchedInit = {
+    tosAstro: false,
+    usernameAstro: false,
+    passwordAstro: false,
+    confirmAstro: false,
+  };
+  let touched = touchedInit;
+  let checked = [];
+
+  const validate = (fieldName, value, force) => {
+    const nextState = { ...formState, [fieldName]: value };
+    if (touched[fieldName] || force) {
+      const res = suite(nextState, fieldName);
+      res.done(r => {
+        const btn = document.querySelector('#submit');
+        if (r.isValid()) {
+          btn.removeAttribute('disabled');
+        } else {
+          btn.setAttribute('disabled', true);
+        }
+      })
+    }
+    formState = nextState;
+  }
+
+  /**
+   * Blurring field makes it "touched" and candidate for validation
+   */
+  const handleBlur = fieldName => {
+    if (!touched[fieldName]) {
+      touched = {...touched, ...{ [fieldName]: true }};
+      // First time this field is considered "touched" e.g. user just tab'd or clicked out
+      // of the field. As such, we now need to validate said field for the first time!
+      validate(fieldName, formState[fieldName], true);
+    }
+  }
+
+  const handleCheckbox = (ev) => {
+    // Since often user will simply click (not TAB then SPACE select
+    // checked) we consider any interaction w/checkbox as now "touched"
+    touched = { ...touched, ...{ tosAstro: true }};
+    validate('tosAstro', !!ev.target.checked, true);
+  }
+
+  const handleChange = ({ target: { value, name } }) => {
+    console.log('handleChange');
+    validate(name, value);
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    validate();
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const username = document.querySelector('#uname-astro');
+    const password = document.querySelector('#pword-astro');
+    const confirm = document.querySelector('#confirm-astro');
+    const submitButton = document.querySelector('#submit');
+
+    const form = document.querySelector('form');
+    form.addEventListener('submit', handleSubmit);
+
+    const agrees = document.querySelector('#agrees');
+    agrees.addEventListener('change', handleCheckbox);
+
+    // Change events
+    [username, password, confirm].forEach(el => el.addEventListener('change', handleChange));
+
+    // Blur events
+    [username, password, confirm].forEach((element) => {
+      element.addEventListener('blur', (ev) => {
+        handleBlur(ev.target.name);
+      });
+    });
+  });
+</script>
 <style>
 .form {
   width: 80%;

--- a/playgrounds/SignupForm/src/components/astro/AstroComponents.astro
+++ b/playgrounds/SignupForm/src/components/astro/AstroComponents.astro
@@ -59,9 +59,7 @@
   </AgCard>
 </section>
 <script>
-  // TODO -- Need to add error hints
-  // isInvalid={result.hasErrors('usernameAstro')}
-  // invalidText={[...result.getErrors('usernameAstro')]}
+
   import suite from "./suiteAstro";
 
   let result = suite.get();
@@ -76,62 +74,104 @@
   let touched = touchedInit;
   let checked = [];
 
-  const validate = (fieldName, value, force) => {
-    const nextState = { ...formState, [fieldName]: value };
-    if (touched[fieldName] || force) {
-      const res = suite(nextState, fieldName);
-      res.done(r => {
-        const btn = document.querySelector('#submit');
-        if (r.isValid()) {
-          btn.removeAttribute('disabled');
-        } else {
-          btn.setAttribute('disabled', true);
-        }
-      })
-    }
-    formState = nextState;
-  }
-
-  /**
-   * Blurring field makes it "touched" and candidate for validation
-   */
-  const handleBlur = fieldName => {
-    if (!touched[fieldName]) {
-      touched = {...touched, ...{ [fieldName]: true }};
-      // First time this field is considered "touched" e.g. user just tab'd or clicked out
-      // of the field. As such, we now need to validate said field for the first time!
-      validate(fieldName, formState[fieldName], true);
-    }
-  }
-
-  const handleCheckbox = (ev) => {
-    // Since often user will simply click (not TAB then SPACE select
-    // checked) we consider any interaction w/checkbox as now "touched"
-    touched = { ...touched, ...{ tosAstro: true }};
-    validate('tosAstro', !!ev.target.checked, true);
-  }
-
-  const handleChange = ({ target: { value, name } }) => {
-    console.log('handleChange');
-    validate(name, value);
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    validate();
-  };
-
   document.addEventListener('DOMContentLoaded', () => {
     const username = document.querySelector('#uname-astro');
     const password = document.querySelector('#pword-astro');
     const confirm = document.querySelector('#confirm-astro');
     const submitButton = document.querySelector('#submit');
-
     const form = document.querySelector('form');
-    form.addEventListener('submit', handleSubmit);
 
     const agrees = document.querySelector('#agrees');
-    agrees.addEventListener('change', handleCheckbox);
+
+    const fields = {
+      tosAstro: agrees,
+      usernameAstro: username,
+      passwordAstro: password,
+      confirmAstro: confirm
+    }
+
+    const removeError = (field) => {
+      field.classList.remove('input-error', 'choice-input-error')
+      // Grabs next sibling, checks if it has field-error class; and if so, removes
+      const possibleErrorSpan = field.nextElementSibling;
+      if (possibleErrorSpan && possibleErrorSpan.classList.contains('field-error')) {
+        possibleErrorSpan.remove();
+      }
+    }
+
+    const insertError = (fieldName, message) => {
+      let span = document.createElement('span');
+      let fieldWithErrorClasses = 'input-error';
+      const field = fields[fieldName];
+
+      if (fieldName === 'tosAstro') {
+        fieldWithErrorClasses = 'choice-input-error';
+      } else {
+        // Remove any previous errors
+        removeError(field);
+        // If we have a message and it's not checkbox, we add error hint span
+        if (!message.length) {
+          // We've removed the error but there's no error message so we return
+          // early so no error classes are applied to the field element
+          return;
+        } else {
+          span.textContent = message.join(' ');
+          span.setAttribute('role', 'status')
+          span.setAttribute('aria-live', 'polite')
+          span.classList.add('field-error')
+          field.insertAdjacentElement('afterend', span);
+        }
+      }
+      // Apply error classes to the field itself e.g. to get the red border
+      field.classList.add(fieldWithErrorClasses)
+    }
+
+    const validate = (fieldName, value, force) => {
+      const nextState = { ...formState, [fieldName]: value };
+      if (touched[fieldName] || force) {
+        const res = suite(nextState, fieldName);
+        res.done(r => {
+          const btn = document.querySelector('#submit');
+          if (r.isValid()) {
+            btn.removeAttribute('disabled');
+            removeError(fieldName);
+          } else {
+            btn.setAttribute('disabled', true);
+            insertError(fieldName, r.getErrors(fieldName));
+          }
+        })
+      }
+      formState = nextState;
+    }
+
+    /**
+     * Blurring field makes it "touched" and candidate for validation
+     */
+    const handleBlur = fieldName => {
+      if (!touched[fieldName]) {
+        touched = {...touched, ...{ [fieldName]: true }};
+        // First time this field is considered "touched" e.g. user just tab'd or clicked out
+        // of the field. As such, we now need to validate said field for the first time!
+        validate(fieldName, formState[fieldName], true);
+      }
+    }
+
+    const handleCheckbox = (ev) => {
+      // Since often user will simply click (not TAB then SPACE select
+      // checked) we consider any interaction w/checkbox as now "touched"
+      touched = { ...touched, ...{ tosAstro: true }};
+      validate('tosAstro', !!ev.target.checked, true);
+    }
+
+    const handleChange = ({ target: { value, name } }) => {
+      console.log('handleChange');
+      validate(name, value);
+    };
+
+    const handleSubmit = (e) => {
+      e.preventDefault();
+      validate();
+    };
 
     // Change events
     [username, password, confirm].forEach(el => el.addEventListener('change', handleChange));
@@ -142,6 +182,10 @@
         handleBlur(ev.target.name);
       });
     });
+
+    // Attach form submit and checkbox event handlers
+    form.addEventListener('submit', handleSubmit);
+    agrees.addEventListener('change', handleCheckbox);
   });
 </script>
 <style>

--- a/playgrounds/SignupForm/src/components/astro/suiteAstro.js
+++ b/playgrounds/SignupForm/src/components/astro/suiteAstro.js
@@ -1,0 +1,32 @@
+import { create, test, enforce, warn, only } from "vest";
+
+const suite = create((data = {}, currentField) => {
+  only(currentField);
+
+  test("usernameAstro", "Username is required", () => {
+    enforce(data.usernameAstro).isNotBlank();
+  });
+
+  test("usernameAstro", "Username must be at least 3 characters long", () => {
+    enforce(data.usernameAstro).longerThanOrEquals(3);
+  });
+
+  test("passwordAstro", "Must be at least 5 characters", () => {
+    enforce(data.passwordAstro).longerThan(4);
+  });
+
+  test("passwordAstro", "Password is weak, Maybe add a number?", () => {
+    warn();
+    enforce(data.passwordAstro).matches(/[0-9]/);
+  });
+
+  test("confirmAstro", "Passwords do not match", () => {
+    enforce(data.confirmAstro).equals(data.passwordAstro);
+  });
+
+  test("tosAstro", () => {
+    enforce(data.tosAstro).isTruthy();
+  });
+});
+
+export default suite;


### PR DESCRIPTION
- [ ] Error field hints e.g. `invalidText`
- [x] Vest validation

* Gets some form validation using Vest working in the astro-agnostic SignupForm playground. 

Note the goal here is to eventually have the capabilities to compare Astro based signup form's TTI vs. React client hydrated one.

Related bug in Astro integration: https://github.com/withastro/astro/issues/3246 (we could probably just go back to manually importing the common.min.css for now)

___

See `playgrounds/SignupForm/src/components/astro/AstroComponents.astro`
![image](https://user-images.githubusercontent.com/142403/166153876-70bd68a1-8bf3-4ce8-936e-602d7e6335e6.png)
