### PR TITLE
Fix breadcrumb template URL in Vue

### DIFF
--- a/agnostic-vue/src/components/Breadcrumb.vue
+++ b/agnostic-vue/src/components/Breadcrumb.vue
@@ -8,7 +8,7 @@
       >
         <a
           v-if="index !== routes.length - 1 && route.url"
-          href="{route.url}"
+          :href="route.url"
         >{{ route.label }}</a>
         <span v-else>{{ route.label }}</span>
       </li>


### PR DESCRIPTION
# Pull Request Template

## Description

Binding of URL for breadcrumb items is not using the correct Vue syntax. The result is that the links are always pointing to the constant string `{route.url}`. Probably some copy/paste leftover from other code in JSX syntax.

This can also be seen in the documentation examples at 

https://www.agnosticui.com/docs/components/breadcrumbs.html#examples

Hovering any one of the links will show the broken text instead of the expected target.

## Checklist:

Please delete options that are not relevant.

- [x] Is this a bug fix
- [ ] Tests passing?

_We realize above checklist is pretty intimidating, reach out with an at mention on your issue if you're interested in contributing but need some clarifications!_
