### PR TITLE
Update loader.md docs missing backslash at Loader tag

### DIFF
--- a/site/docs/docs/components/loader.md
+++ b/site/docs/docs/components/loader.md
@@ -107,9 +107,9 @@ Vue 3: [component source](https://github.com/AgnosticUI/agnosticui/blob/master/a
 </script>
 <div>
   <Loader />
-  <Loader size="small">
-  <Loader size="large">
-  <Loader size="xlarge">
+  <Loader size="small" />
+  <Loader size="large" />
+  <Loader size="xlarge" />
 </div>
 ```
 </details>


### PR DESCRIPTION
# Fix Svelte Loader Element Docs

## Description

There was an error in the Svelte documentation with the loader element. There was a backslash missing in the code example.


## Checklist:

Please delete options that are not relevant.

- [x ] Have you updated the docs? These live in [site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/site/docs)

