### PR TITLE
Fix monochrome Alert variant styling

### DIFF
--- a/v2/lib/src/components/Alert/core/_Alert.ts
+++ b/v2/lib/src/components/Alert/core/_Alert.ts
@@ -118,8 +118,11 @@ export class AgAlert extends LitElement implements AlertProps {
       border-inline-start-color: var(--ag-primary);
     }
     .alert-monochrome {
-      background-color: var(--ag-background-primary-inverted);
-      color: var(--ag-text-primary-inverted);
+      background-color: var(--ag-info-background);
+      color: var(--ag-text-primary);
+    }
+    .alert-bordered.alert-monochrome {
+      border-color: var(--ag-text-primary);
     }
     .alert-border-left.alert-monochrome {
       border-inline-start-color: var(--ag-text-primary);


### PR DESCRIPTION
## Summary
- Use `--ag-info-background` for consistent background with other variants
- Use `--ag-text-primary` for color (inverts properly in dark mode)
- Add bordered variant override with `--ag-text-primary` border color

## Test plan
- [ ] Verify monochrome Alert displays correctly in light mode
- [ ] Verify monochrome Alert displays correctly in dark mode
- [ ] Verify bordered monochrome Alert has proper border color
- [ ] Verify border-left monochrome Alert has proper left border color

Fixes #276