### PR TITLE
Fix #279: Bordered alert variants now use correct border colors

### DIFF
--- a/v2/lib/src/components/Alert/core/_Alert.ts
+++ b/v2/lib/src/components/Alert/core/_Alert.ts
@@ -76,6 +76,22 @@ export class AgAlert extends LitElement implements AlertProps {
     .alert-bordered {
       border-color: var(--ag-border);
     }
+    .alert-bordered.alert-warning {
+      border-color: var(--ag-warning);
+    }
+    .alert-bordered.alert-info {
+      border-color: var(--ag-info);
+    }
+    .alert-bordered.alert-success {
+      border-color: var(--ag-success);
+    }
+    .alert-bordered.alert-danger,
+    .alert-bordered.alert-error {
+      border-color: var(--ag-danger);
+    }
+    .alert-bordered.alert-primary {
+      border-color: var(--ag-primary);
+    }
     .alert-border-left {
       border-inline-start-width: var(--ag-border-width-3);
       border-inline-start-color: var(--ag-border);


### PR DESCRIPTION
The bordered alerts were using the default --ag-border color for all variants. Now each variant uses its corresponding color (e.g., success uses --ag-success) matching the borderedLeft behavior.

# Pull Request

## What does this change?

Brief description of the change and why it's needed.

Fixes #(issue number, if applicable)

## Checklist

- [ ] Bug fix or new feature?
- [ ] Tests passing?
- [ ] Docs updated? (if needed - see [v2/site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/v2/site/docs))

---

**Note:** If you're unsure about anything or need help, just @ mention in your PR or the related issue. We're here to help!
