### PR TITLE
Fix #286: Add disabled individual card state examples to SelectionCardGroup

### DIFF
--- a/v2/site/docs/examples/SelectionCardGroupExamples.vue
+++ b/v2/site/docs/examples/SelectionCardGroupExamples.vue
@@ -176,6 +176,33 @@
     </VueSelectionCardGroup>
 
     <div class="mbe4">
+      <h2>Disabled Individual Card State</h2>
+      <p class="mbs2 mbe3">Individual cards can be disabled while others remain interactive</p>
+    </div>
+    <VueSelectionCardGroup
+      type="radio"
+      name="disabled-individual-example"
+      legend="Disabled individual cards"
+      class="mbe4"
+    >
+      <VueSelectionCard value="a" label="Option A">
+        <div style="padding: 1rem; text-align: center;">Option A</div>
+      </VueSelectionCard>
+      <VueSelectionCard disabled value="b" label="Option B">
+        <div style="padding: 1rem; text-align: center;">Option B</div>
+      </VueSelectionCard>
+      <VueSelectionCard value="c" label="Option C">
+        <div style="padding: 1rem; text-align: center;">Option C</div>
+      </VueSelectionCard>
+      <VueSelectionCard disabled value="d" label="Option D">
+        <div style="padding: 1rem; text-align: center;">Option D</div>
+      </VueSelectionCard>
+      <VueSelectionCard value="e" label="Option E">
+        <div style="padding: 1rem; text-align: center;">Option E</div>
+      </VueSelectionCard>
+    </VueSelectionCardGroup>
+
+    <div class="mbe4">
       <h2>Pricing Tiers Example</h2>
       <p class="mbs2 mbe3">Common use case for plan selection</p>
     </div>

--- a/v2/site/docs/examples/SelectionCardGroupLitExamples.js
+++ b/v2/site/docs/examples/SelectionCardGroupLitExamples.js
@@ -194,6 +194,34 @@ export class SelectionCardGroupLitExamples extends LitElement {
           </ag-selection-card>
         </ag-selection-card-group>
 
+        <!-- Disabled Individual Card State -->
+        <div class="mbe4">
+          <h2>Disabled Individual Card State</h2>
+          <p class="mbs2 mbe3">Individual cards can be disabled while others remain interactive</p>
+        </div>
+        <ag-selection-card-group
+          type="radio"
+          name="disabled-individual-example"
+          legend="Disabled individual cards"
+          class="mbe4"
+        >
+          <ag-selection-card value="a" label="Option A">
+            <div style="padding: 1rem; text-align: center;">Option A</div>
+          </ag-selection-card>
+          <ag-selection-card disabled value="b" label="Option B">
+            <div style="padding: 1rem; text-align: center;">Option B</div>
+          </ag-selection-card>
+          <ag-selection-card value="c" label="Option C">
+            <div style="padding: 1rem; text-align: center;">Option C</div>
+          </ag-selection-card>
+          <ag-selection-card disabled value="d" label="Option D">
+            <div style="padding: 1rem; text-align: center;">Option D</div>
+          </ag-selection-card>
+          <ag-selection-card value="e" label="Option E">
+            <div style="padding: 1rem; text-align: center;">Option E</div>
+          </ag-selection-card>
+        </ag-selection-card-group>
+
         <!-- Pricing Tiers Example -->
         <div class="mbe4">
           <h2>Pricing Tiers Example</h2>

--- a/v2/site/docs/examples/SelectionCardGroupReactExamples.jsx
+++ b/v2/site/docs/examples/SelectionCardGroupReactExamples.jsx
@@ -153,6 +153,34 @@ export default function SelectionCardGroupExamples() {
         </ReactSelectionCard>
       </ReactSelectionCardGroup>
 
+      {/* Disabled Individual Card State */}
+      <div className="mbe4">
+        <h2>Disabled Individual Card State</h2>
+        <p className="mbs2 mbe3">Individual cards can be disabled while others remain interactive</p>
+      </div>
+      <ReactSelectionCardGroup
+        type="radio"
+        name="disabled-individual-example"
+        legend="Disabled individual cards"
+        className="mbe4"
+      >
+        <ReactSelectionCard value="a" label="Option A">
+          <div style={{ padding: "1rem", textAlign: "center" }}>Option A</div>
+        </ReactSelectionCard>
+        <ReactSelectionCard disabled value="b" label="Option B">
+          <div style={{ padding: "1rem", textAlign: "center" }}>Option B</div>
+        </ReactSelectionCard>
+        <ReactSelectionCard value="c" label="Option C">
+          <div style={{ padding: "1rem", textAlign: "center" }}>Option C</div>
+        </ReactSelectionCard>
+        <ReactSelectionCard disabled value="d" label="Option D">
+          <div style={{ padding: "1rem", textAlign: "center" }}>Option D</div>
+        </ReactSelectionCard>
+        <ReactSelectionCard value="e" label="Option E">
+          <div style={{ padding: "1rem", textAlign: "center" }}>Option E</div>
+        </ReactSelectionCard>
+      </ReactSelectionCardGroup>
+
       {/* Pricing Tiers Example */}
       <div className="mbe4">
         <h2>Pricing Tiers Example</h2>


### PR DESCRIPTION
Add "Disabled Individual Card State" section to SelectionCardGroup examples
for Vue, Lit, and React. This matches the existing pattern in SelectionButtonGroup
and enables testing that keyboard navigation properly skips disabled cards.
