### PR TITLE
Fix summary section font size in onboarding playbook

### DIFF
--- a/v2/playbooks/onboarding/lit-example/src/onboarding-wizard.ts
+++ b/v2/playbooks/onboarding/lit-example/src/onboarding-wizard.ts
@@ -206,7 +206,6 @@ export class OnboardingWizard extends LitElement {
 
     .summary-section p {
       margin: 0;
-      font-size: var(--ag-font-size-lg);
     }
 
     .alert-wrapper {

--- a/v2/playbooks/onboarding/react-example/src/index.css
+++ b/v2/playbooks/onboarding/react-example/src/index.css
@@ -157,7 +157,6 @@ body {
 
 .summary-section p {
   margin: 0;
-  font-size: var(--ag-font-size-lg);
 }
 
 .alert-wrapper {

--- a/v2/playbooks/onboarding/vue-example/src/style.css
+++ b/v2/playbooks/onboarding/vue-example/src/style.css
@@ -157,7 +157,6 @@ body {
 
 .summary-section p {
   margin: 0;
-  font-size: var(--ag-font-size-lg);
 }
 
 .alert-wrapper {


### PR DESCRIPTION
## Summary
Remove oversized `font-size: var(--ag-font-size-lg)` from `.summary-section p` in all three onboarding playbook examples (React, Vue, Lit).

The large font size was making the summary text too prominent on Step 3.