### PR TITLE
Add #273: Card media slot — edge-to-edge image/video with top/bottom position

### DIFF
--- a/v2/lib/src/components/Card/vue/VueCard.vue
+++ b/v2/lib/src/components/Card/vue/VueCard.vue
@@ -6,8 +6,14 @@
     .animated="animated"
     :rounded="rounded"
     :variant="variant"
+    .hasMedia="hasMedia"
+    .mediaPosition="mediaPosition"
     v-bind="$attrs"
   >
+    <slot
+      name="media"
+      slot="media"
+    />
     <slot
       name="header"
       slot="header"
@@ -22,7 +28,7 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, ref, type PropType } from "vue";
-import type { CardProps, CardVariant, CardRounded } from "../core/Card";
+import type { CardProps, CardVariant, CardRounded, CardMediaPosition } from "../core/Card";
 import "../core/Card"; // Registers the ag-card web component
 
 export default defineComponent({
@@ -48,6 +54,14 @@ export default defineComponent({
       type: String as PropType<CardVariant>,
       default: "" as CardVariant,
     },
+    hasMedia: {
+      type: Boolean,
+      default: false,
+    },
+    mediaPosition: {
+      type: String as PropType<CardMediaPosition>,
+      default: "top" as CardMediaPosition,
+    },
   },
   setup(props) {
     const agComponent = ref<(HTMLElement & CardProps) | null>(null);
@@ -68,6 +82,8 @@ export default defineComponent({
       animated: props.animated,
       rounded: props.rounded,
       variant: props.variant,
+      hasMedia: props.hasMedia,
+      mediaPosition: props.mediaPosition,
     };
   },
 });

--- a/v2/playgrounds/lit/src/stories/Card.stories.ts
+++ b/v2/playgrounds/lit/src/stories/Card.stories.ts
@@ -358,6 +358,55 @@ export const CombinedFeatures: Story = {
   `,
 };
 
+export const MediaTop: Story = {
+  args: {
+    rounded: "md",
+  },
+  render: (args) => html`
+    <ag-card
+      has-media
+      media-position="top"
+      rounded=${args.rounded || ""}
+      .shadow=${args.shadow}
+      .animated=${args.animated}
+    >
+      <img
+        slot="media"
+        src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+        alt="Mountain landscape"
+      />
+      <h3 slot="header" style="margin: 0;">Mountain Retreat</h3>
+      <p>A breathtaking mountain landscape captured at golden hour.</p>
+      <div slot="footer">
+        <button style="padding: 0.5rem 1rem;">View Gallery</button>
+      </div>
+    </ag-card>
+  `,
+};
+
+export const MediaBottom: Story = {
+  args: {
+    rounded: "md",
+  },
+  render: (args) => html`
+    <ag-card
+      has-media
+      media-position="bottom"
+      rounded=${args.rounded || ""}
+      .shadow=${args.shadow}
+      .animated=${args.animated}
+    >
+      <h3 slot="header" style="margin: 0;">Mountain Retreat</h3>
+      <p>A breathtaking mountain landscape captured at golden hour.</p>
+      <img
+        slot="media"
+        src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+        alt="Mountain landscape"
+      />
+    </ag-card>
+  `,
+};
+
 export const Gallery: Story = {
   render: () => html`
     <div

--- a/v2/playgrounds/react/src/stories/Card.stories.tsx
+++ b/v2/playgrounds/react/src/stories/Card.stories.tsx
@@ -255,6 +255,43 @@ export const CombinedFeatures: Story = {
   ),
 };
 
+export const MediaTop: Story = {
+  args: {
+    rounded: 'md',
+  },
+  render: (args) => (
+    <ReactCard {...args} hasMedia mediaPosition="top">
+      <img
+        slot="media"
+        src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+        alt="Mountain landscape"
+      />
+      <h3 slot="header" style={{ margin: 0 }}>Mountain Retreat</h3>
+      <p>A breathtaking mountain landscape captured at golden hour.</p>
+      <div slot="footer">
+        <button style={{ padding: '0.5rem 1rem' }}>View Gallery</button>
+      </div>
+    </ReactCard>
+  ),
+};
+
+export const MediaBottom: Story = {
+  args: {
+    rounded: 'md',
+  },
+  render: (args) => (
+    <ReactCard {...args} hasMedia mediaPosition="bottom">
+      <h3 slot="header" style={{ margin: 0 }}>Mountain Retreat</h3>
+      <p>A breathtaking mountain landscape captured at golden hour.</p>
+      <img
+        slot="media"
+        src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+        alt="Mountain landscape"
+      />
+    </ReactCard>
+  ),
+};
+
 export const Gallery: Story = {
   render: () => (
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: '1.5rem' }}>

--- a/v2/playgrounds/vue/src/stories/Card.stories.ts
+++ b/v2/playgrounds/vue/src/stories/Card.stories.ts
@@ -353,6 +353,49 @@ export const CombinedFeatures: Story = {
   }),
 };
 
+export const MediaTop: Story = {
+  render: () => ({
+    components: { VueCard },
+    template: `
+      <VueCard :hasMedia="true" :mediaPosition="'top'" rounded="md" :shadow="true">
+        <template #media>
+          <img
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+        </template>
+        <template #header>
+          <h3 style="margin: 0;">Mountain Retreat</h3>
+        </template>
+        <p>A breathtaking mountain landscape captured at golden hour.</p>
+        <template #footer>
+          <button style="padding: 0.5rem 1rem;">View Gallery</button>
+        </template>
+      </VueCard>
+    `,
+  }),
+};
+
+export const MediaBottom: Story = {
+  render: () => ({
+    components: { VueCard },
+    template: `
+      <VueCard :hasMedia="true" :mediaPosition="'bottom'" rounded="md" :shadow="true">
+        <template #header>
+          <h3 style="margin: 0;">Mountain Retreat</h3>
+        </template>
+        <p>A breathtaking mountain landscape captured at golden hour.</p>
+        <template #media>
+          <img
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+        </template>
+      </VueCard>
+    `,
+  }),
+};
+
 export const Gallery: Story = {
   render: () => ({
     components: { VueCard },

--- a/v2/site/docs/components/card.md
+++ b/v2/site/docs/components/card.md
@@ -75,6 +75,16 @@ The CLI copies source code directly into your project, giving you full visibilit
         <VueButton variant="primary" shape="rounded">Action</VueButton>
       </template>
     </VueCard>
+
+    <VueCard :has-media="true" media-position="top" rounded="md" :shadow="true">
+      <template #media>
+        <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop" alt="Mountain landscape" />
+      </template>
+      <template #header>
+        <h4 style="margin: 0;">Media Card</h4>
+      </template>
+      <p>Edge-to-edge image with rounded corners.</p>
+    </VueCard>
   </section>
 </template>
 
@@ -128,6 +138,16 @@ export default function CardExamples() {
           Action
         </ReactButton>
       </ReactCard>
+
+      <ReactCard hasMedia mediaPosition="top" rounded="md" shadow>
+        <img
+          slot="media"
+          src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+          alt="Mountain landscape"
+        />
+        <h3 slot="header" style={{ margin: 0 }}>Media Card</h3>
+        <p>Edge-to-edge image with rounded corners.</p>
+      </ReactCard>
     </section>
   );
 }
@@ -167,27 +187,36 @@ export default function CardExamples() {
 
   <ag-button variant="primary" shape="rounded" slot="footer">Action</ag-button>
 </ag-card>
+
+<ag-card has-media media-position="top" rounded="md" shadow>
+  <img slot="media" src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop" alt="Mountain landscape" />
+  <h4 slot="header" style="margin: 0;">Media Card</h4>
+  <p>Edge-to-edge image with rounded corners.</p>
+</ag-card>
 ```
 
 :::
 
 ## Props
 
-| Prop       | Type                                                | Default | Description                                                              |
-| ---------- | --------------------------------------------------- | ------- | ------------------------------------------------------------------------ |
-| `stacked`  | `boolean`                                           | `false` | Applies vertical spacing between slotted children                        |
-| `shadow`   | `boolean`                                           | `false` | Adds box-shadow with enhanced hover effect                               |
-| `animated` | `boolean`                                           | `false` | Enables smooth transitions on hover (translateY + shadow)                |
-| `rounded`  | `'sm' \| 'md' \| 'lg' \| boolean`                   | `''`    | Border radius size. Use `true` for default 'md' or specify 'sm'/'lg'     |
-| `variant`  | `'success' \| 'info' \| 'error' \| 'warning' \| ''` | `''`    | Color variant for semantic meaning                                       |
+| Prop            | Type                                                | Default  | Description                                                              |
+| --------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------ |
+| `stacked`       | `boolean`                                           | `false`  | Applies vertical spacing between slotted children                        |
+| `shadow`        | `boolean`                                           | `false`  | Adds box-shadow with enhanced hover effect                               |
+| `animated`      | `boolean`                                           | `false`  | Enables smooth transitions on hover (translateY + shadow)                |
+| `rounded`       | `'sm' \| 'md' \| 'lg' \| boolean`                   | `''`     | Border radius size. Use `true` for default 'md' or specify 'sm'/'lg'     |
+| `variant`       | `'success' \| 'info' \| 'error' \| 'warning' \| ''` | `''`     | Color variant for semantic meaning                                       |
+| `hasMedia`      | `boolean`                                           | `false`  | Enables the `media` slot for edge-to-edge image/video rendering          |
+| `mediaPosition` | `'top' \| 'bottom'`                                 | `'top'`  | Whether media renders above or below the header/content/footer           |
 
 ## Slots
 
-| Slot      | Description                                                 |
-| --------- | ----------------------------------------------------------- |
-| `header`  | Optional header content displayed at the top of the card    |
-| `default` | Main content of the card                                    |
-| `footer`  | Optional footer content displayed at the bottom of the card |
+| Slot      | Description                                                                          |
+| --------- | ------------------------------------------------------------------------------------ |
+| `media`   | Edge-to-edge media content (image/video). Requires `hasMedia` to be `true`           |
+| `header`  | Optional header content displayed at the top of the card                             |
+| `default` | Main content of the card                                                             |
+| `footer`  | Optional footer content displayed at the bottom of the card                          |
 
 ## CSS Shadow Parts
 
@@ -196,6 +225,7 @@ Shadow Parts allow you to style internal elements of the card from outside the s
 | Part              | Description                                             |
 | ----------------- | ------------------------------------------------------- |
 | `ag-card-wrapper` | The main wrapper element that contains all card content |
+| `ag-card-media`   | The media wrapper (present when `hasMedia` is `true`)   |
 | `ag-card-header`  | The header section wrapper (even when empty)            |
 | `ag-card-content` | The main content section wrapper                        |
 | `ag-card-footer`  | The footer section wrapper (even when empty)            |
@@ -297,6 +327,56 @@ Use slots for clearly separated header/footer sections. The header and footer au
 </VueCard>
 ```
 
+### Media Card
+
+Use `hasMedia` with the `media` slot to render images or video edge-to-edge inside the card. The media wrapper has no padding — it bleeds to the card's edges. Combined with `rounded`, the image corners clip correctly via `overflow: hidden`.
+
+```vue
+<!-- Media at the top (default) -->
+<VueCard :has-media="true" media-position="top" rounded="md" :shadow="true">
+  <template #media>
+    <img src="https://images.unsplash.com/photo-..." alt="Descriptive alt text" />
+  </template>
+  <template #header>
+    <h3 style="margin: 0;">Card Title</h3>
+  </template>
+  <p>Card body content goes here.</p>
+  <template #footer>
+    <VueButton>View Details</VueButton>
+  </template>
+</VueCard>
+
+<!-- Media at the bottom -->
+<VueCard :has-media="true" media-position="bottom" rounded="md">
+  <template #header>
+    <h3 style="margin: 0;">Card Title</h3>
+  </template>
+  <p>Card body content goes here.</p>
+  <template #media>
+    <img src="https://images.unsplash.com/photo-..." alt="Descriptive alt text" />
+  </template>
+</VueCard>
+```
+
+In Lit (Web Components):
+
+```html
+<ag-card has-media media-position="top" rounded="md" shadow>
+  <img slot="media" src="https://images.unsplash.com/photo-..." alt="Descriptive alt text" />
+  <h3 slot="header" style="margin: 0;">Card Title</h3>
+  <p>Card body content goes here.</p>
+  <ag-button slot="footer">View Details</ag-button>
+</ag-card>
+```
+
+::: tip Accessibility
+Always provide a meaningful `alt` attribute on `<img>` elements slotted into `media`. If the image is purely decorative, use `alt=""`.
+:::
+
+::: tip Styling media height
+By default, slotted images render at their natural aspect ratio (`height: auto`). To constrain height, target the `::part(ag-card-media)` shadow part or use a wrapping `<div>` with a fixed height and `overflow: hidden` inside the slot.
+:::
+
 ### Clickable Card Pattern
 
 Create fully clickable cards while maintaining accessibility:
@@ -335,4 +415,7 @@ The `card-primary-action` class creates a pseudo-element that covers the entire 
 - **Responsive Design**: Cards are `width: 100%` by default and work well in grid layouts
 - **Lit Property Binding**: In Lit templates, use property bindings for boolean props
 - **Reduced Motion**: Animation transitions are automatically disabled for users who prefer reduced motion
+- **Media + `rounded`**: When `hasMedia` is `true`, `overflow: hidden` is applied to the host so the image clips correctly to the card's border-radius. No extra CSS is needed.
+- **Media height**: Slotted `<img>` and `<video>` elements default to `width: 100%; height: auto; object-fit: cover`. Constrain the height via `::part(ag-card-media)` or by wrapping the image in a sized `<div>`.
+- **Horizontal layout**: Inline-start/inline-end media positions are out of scope and deferred to a future issue.
 - All three framework implementations share the same underlying styles and behavior

--- a/v2/site/docs/examples/CardExamples.vue
+++ b/v2/site/docs/examples/CardExamples.vue
@@ -239,6 +239,47 @@
     </div>
 
     <div class="mbe4">
+      <h2>Media Card (Top)</h2>
+      <p class="mbs2 mbe3">Use <code>:has-media="true"</code> with <code>media-position="top"</code> for edge-to-edge media above the card content.</p>
+    </div>
+    <div class="stacked-mobile">
+      <VueCard :has-media="true" media-position="top" rounded="md" :shadow="true" style="max-width: 400px;">
+        <template #media>
+          <img
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+        </template>
+        <template #header>
+          <h3 class="m0">Mountain Retreat</h3>
+        </template>
+        <p>A breathtaking mountain landscape captured at golden hour.</p>
+        <template #footer>
+          <VueButton>View Gallery</VueButton>
+        </template>
+      </VueCard>
+    </div>
+
+    <div class="mbe4">
+      <h2>Media Card (Bottom)</h2>
+      <p class="mbs2 mbe3">Use <code>media-position="bottom"</code> to render media below the card content.</p>
+    </div>
+    <div class="stacked-mobile">
+      <VueCard :has-media="true" media-position="bottom" rounded="md" :shadow="true" style="max-width: 400px;">
+        <template #header>
+          <h3 class="m0">Mountain Retreat</h3>
+        </template>
+        <p>A breathtaking mountain landscape captured at golden hour.</p>
+        <template #media>
+          <img
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+        </template>
+      </VueCard>
+    </div>
+
+    <div class="mbe4">
       <h2>Customized with CSS Shadow Parts</h2>
     </div>
     <div class="stacked-mobile">

--- a/v2/site/docs/examples/CardLitExamples.js
+++ b/v2/site/docs/examples/CardLitExamples.js
@@ -185,6 +185,43 @@ export class CardLitExamples extends LitElement {
           </ag-card>
         </div>
 
+        <!-- Media Card — Top -->
+        <div class="mbe4">
+          <h2>Media Card (Top)</h2>
+          <p class="mbs2 mbe3">Use the <code>has-media</code> attribute with <code>media-position="top"</code> for edge-to-edge media above the card content.</p>
+        </div>
+        <div class="stacked-mobile">
+          <ag-card has-media media-position="top" rounded="md" shadow style="max-width: 400px;">
+            <img
+              slot="media"
+              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+              alt="Mountain landscape"
+            />
+            <h3 slot="header" class="m0">Mountain Retreat</h3>
+            <p>A breathtaking mountain landscape captured at golden hour.</p>
+            <div slot="footer">
+              <ag-button>View Gallery</ag-button>
+            </div>
+          </ag-card>
+        </div>
+
+        <!-- Media Card — Bottom -->
+        <div class="mbe4">
+          <h2>Media Card (Bottom)</h2>
+          <p class="mbs2 mbe3">Use <code>media-position="bottom"</code> to render media below the card content.</p>
+        </div>
+        <div class="stacked-mobile">
+          <ag-card has-media media-position="bottom" rounded="md" shadow style="max-width: 400px;">
+            <h3 slot="header" class="m0">Mountain Retreat</h3>
+            <p>A breathtaking mountain landscape captured at golden hour.</p>
+            <img
+              slot="media"
+              src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+              alt="Mountain landscape"
+            />
+          </ag-card>
+        </div>
+
         <!-- Customized with CSS Shadow Parts -->
         <div class="mbe4">
           <h2>Customized with CSS Shadow Parts</h2>

--- a/v2/site/docs/examples/CardReactExamples.jsx
+++ b/v2/site/docs/examples/CardReactExamples.jsx
@@ -184,6 +184,47 @@ export default function CardReactExamples() {
         </ReactCard>
       </div>
 
+      {/* Media Card — Top */}
+      <div className="mbe4">
+        <h2>Media Card (Top)</h2>
+        <p className="mbs2 mbe3">
+          Use <code>hasMedia</code> with <code>mediaPosition="top"</code> for edge-to-edge media above the card content.
+        </p>
+      </div>
+      <div className="stacked-mobile">
+        <ReactCard hasMedia mediaPosition="top" rounded="md" shadow style={{ maxWidth: "400px" }}>
+          <img
+            slot="media"
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+          <h3 slot="header" className="m0">Mountain Retreat</h3>
+          <p>A breathtaking mountain landscape captured at golden hour.</p>
+          <div slot="footer">
+            <ReactButton>View Gallery</ReactButton>
+          </div>
+        </ReactCard>
+      </div>
+
+      {/* Media Card — Bottom */}
+      <div className="mbe4">
+        <h2>Media Card (Bottom)</h2>
+        <p className="mbs2 mbe3">
+          Use <code>mediaPosition="bottom"</code> to render media below the card content.
+        </p>
+      </div>
+      <div className="stacked-mobile">
+        <ReactCard hasMedia mediaPosition="bottom" rounded="md" shadow style={{ maxWidth: "400px" }}>
+          <h3 slot="header" className="m0">Mountain Retreat</h3>
+          <p>A breathtaking mountain landscape captured at golden hour.</p>
+          <img
+            slot="media"
+            src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&auto=format&fit=crop"
+            alt="Mountain landscape"
+          />
+        </ReactCard>
+      </div>
+
       {/* Customized with CSS Shadow Parts */}
       <div className="mbe4">
         <h2>Customized with CSS Shadow Parts</h2>


### PR DESCRIPTION
## Summary

- Adds `hasMedia` (boolean) and `mediaPosition` (`'top' | 'bottom'`) props to `ag-card`
- Renders a named `<slot name="media">` inside a `.card-media--top` or `.card-media--bottom` wrapper based on `mediaPosition`; uses Lit's `nothing` when `hasMedia` is false
- CSS: `:host([has-media])` gets `overflow: hidden` to clip media to the card's `border-radius`; partial-radius rules for top/bottom variants; `::slotted(img/video)` defaults (`display: block; width: 100%; height: auto; object-fit: cover`)
- Exposes `::part(ag-card-media)` for external customization
- Updates `VueCard` wrapper: adds `hasMedia`/`mediaPosition` props, `media` slot passthrough, uses `.mediaPosition` **property** binding (not `:media-position` attribute) for reliable Lit web component interop
- Adds `MediaTop` and `MediaBottom` Storybook stories for Lit, React, and Vue
- Adds Media Card (Top/Bottom) examples to all three VitePress doc example files
- Updates `card.md`: props table, slots table, CSS parts table, new "Media Card" design pattern section with Vue + Lit code examples, accessibility tips, and updated Notes

## Test plan

- [ ] Open Lit Storybook → Card → MediaTop: image renders edge-to-edge at top, rounded corners clip correctly
- [ ] Open Lit Storybook → Card → MediaBottom: image renders edge-to-edge at bottom, rounded corners clip correctly
- [ ] Open React Storybook → Card → MediaTop / MediaBottom: same checks
- [ ] Open Vue Storybook → Card → MediaTop / MediaBottom: same checks; confirm `::slotted(img)` CSS applies (image fills card width)
- [ ] Verify `ag-card` without `has-media` attribute is unaffected (no regression)
- [ ] Verify `ag-card` with `has-media` but no `rounded` has no unintended border-radius on media wrapper
- [ ] Check VitePress docs site: Media Card examples render in all three framework tabs