### PR TITLE
Fix #303: AgCheckbox FACE — native form participation (Part of #274)

### DIFF
--- a/v2/lib/src/components/Checkbox/core/_Checkbox.ts
+++ b/v2/lib/src/components/Checkbox/core/_Checkbox.ts
@@ -5,6 +5,7 @@ import {
   createFormControlIds,
   buildAriaDescribedBy,
 } from '../../../shared/form-control-utils';
+import { FaceMixin, syncInnerInputValidity } from '../../../shared/face-mixin';
 
 export type CheckboxSize = 'small' | 'medium' | 'large';
 export type CheckboxTheme = 'default' | 'primary' | 'success' | 'monochrome';
@@ -45,7 +46,7 @@ export interface CheckboxProps {
   onChange?: (event: CheckboxChangeEvent) => void;
 }
 
-export class AgCheckbox extends LitElement implements CheckboxProps {
+export class AgCheckbox extends FaceMixin(LitElement) implements CheckboxProps {
   static override styles = [
     formControlStyles,
     css`
@@ -279,9 +280,6 @@ export class AgCheckbox extends LitElement implements CheckboxProps {
   ];
 
   @property({ type: String })
-  declare name: string;
-
-  @property({ type: String })
   declare value: string;
 
   @property({ type: Boolean, reflect: true })
@@ -331,8 +329,7 @@ export class AgCheckbox extends LitElement implements CheckboxProps {
 
   constructor() {
     super();
-    this.name = '';
-    this.value = '';
+    this.value = 'on';
     this.checked = false;
     this.indeterminate = false;
     this.disabled = false;
@@ -353,12 +350,42 @@ export class AgCheckbox extends LitElement implements CheckboxProps {
     return this.inputRef || null;
   }
 
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Restores checked and indeterminate to their default states.
+   */
+  override formResetCallback(): void {
+    this.checked = false;
+    this.indeterminate = false;
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+  }
+
+  /**
+   * Sync validity to ElementInternals by delegating to the inner
+   * <input type="checkbox">. Required validation is handled natively
+   * by the inner input; we just mirror its state.
+   */
+  private _syncValidity(): void {
+    syncInnerInputValidity(this._internals, this.inputRef);
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
+
   override updated(changedProperties: Map<string, unknown>) {
     super.updated(changedProperties);
 
     // Sync indeterminate state to native input
     if (changedProperties.has('indeterminate') && this.inputRef) {
       this.inputRef.indeterminate = this.indeterminate;
+    }
+
+    // FACE: sync form value and validity for programmatic changes to checked/indeterminate
+    if (changedProperties.has('checked') || changedProperties.has('indeterminate')) {
+      this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+      this._syncValidity();
     }
   }
 
@@ -382,6 +409,10 @@ export class AgCheckbox extends LitElement implements CheckboxProps {
     if (this.indeterminate) {
       this.indeterminate = false;
     }
+
+    // FACE: sync form value and validity on user interaction
+    this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+    this._syncValidity();
 
     // Dispatch custom change event with dual-dispatch pattern
     const changeEvent = new CustomEvent<CheckboxChangeEventDetail>('change', {
@@ -526,5 +557,9 @@ export class AgCheckbox extends LitElement implements CheckboxProps {
     if (this.inputRef && this.indeterminate) {
       this.inputRef.indeterminate = this.indeterminate;
     }
+
+    // FACE: set initial form value and sync validity after first render
+    this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+    this._syncValidity();
   }
 }

--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -369,6 +369,81 @@ must always reflect current state.
 
 ---
 
+## AgCheckbox: Same Pattern, Two Strategies Meet
+
+AgCheckbox is the most instructive component in the rollout because it sits at the
+intersection of both validation strategies. It looks like a checkbox (checked/unchecked,
+`null` when unchecked) so the form value semantics match AgToggle — but internally it
+renders a real `<input type="checkbox">`, which means we can delegate validation to it
+just like AgInput.
+
+### Shadow DOM Inputs Don't Submit to Parent Forms
+
+This is worth spelling out because it's surprising the first time. `AgCheckbox` has an
+inner `<input type="checkbox">` in its shadow DOM with `name` and `value` set on it. You
+might expect that input to submit to the parent form. It doesn't. Shadow DOM inputs are
+isolated from the parent document's form. The inner checkbox was never submitting anything.
+Only `setFormValue()` connects the host element to the parent form.
+
+This is also why FACE is necessary for any component that renders inputs inside shadow DOM.
+The browser can't see them.
+
+### Delegation Still Applies
+
+Even though AgCheckbox is a checkbox-pattern component (null when unchecked), it still has
+an inner `<input type="checkbox">` that runs native constraint validation. So `_syncValidity()`
+can still delegate:
+
+```typescript
+private _syncValidity(): void {
+  syncInnerInputValidity(this._internals, this.inputRef);
+}
+```
+
+The inner `<input type="checkbox" required>` has `validity.valueMissing = true` when
+unchecked. We mirror that into `ElementInternals`. No custom flag logic needed.
+
+This is the delegation strategy working on a non-text input. The `syncInnerInputValidity`
+helper doesn't care what type of input it is — it just mirrors whatever validity state
+the native input has.
+
+### Programmatic Changes Need Syncing Too
+
+AgInput syncs on every keystroke. AgToggle syncs in `_performToggle`. AgCheckbox adds a
+wrinkle: `checked` can be changed programmatically (a "select all" button, test code, a
+parent component setting state). User interaction goes through `handleChange`. Programmatic
+changes go through Lit's `updated()` lifecycle. Both paths need to call `setFormValue` and
+`_syncValidity`:
+
+```typescript
+// User interaction
+handleChange(e: Event) {
+  this.checked = input.checked;
+  this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+  this._syncValidity();
+}
+
+// Programmatic assignment
+updated(changedProperties: Map<string, unknown>) {
+  if (changedProperties.has('checked') || changedProperties.has('indeterminate')) {
+    this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+    this._syncValidity();
+  }
+}
+```
+
+This is the right pattern for any component where state can change through user interaction
+OR programmatic property assignment. It's worth calling out in the article because it's easy
+to wire up the event handler path and forget the programmatic path.
+
+### Indeterminate State
+
+An indeterminate checkbox is visually neither checked nor unchecked. For form submission,
+indeterminate is treated as unchecked: the field is absent from `FormData`. `formResetCallback`
+restores both `checked` and `indeterminate` to false.
+
+---
+
 ## What We Skipped and Why
 
 ### `formAssociatedCallback(form)`


### PR DESCRIPTION
Part of epic #274.

## What Changed

### `v2/lib/src/components/Checkbox/core/_Checkbox.ts`

- Extends `FaceMixin(LitElement)`; local `name` property removed (owned by mixin)
- Default `value` changed to `'on'` (matches native checkbox)
- `_syncValidity()` uses `syncInnerInputValidity()` — delegates to the inner `<input type="checkbox">` rather than implementing required validation from scratch
- `handleChange()` now calls `setFormValue(checked ? value : null)` and `_syncValidity()` on user interaction
- `updated()` extended to sync form value and validity when `checked` or `indeterminate` changes programmatically
- `firstUpdated()` sets initial form value and syncs validity
- `formResetCallback()` restores `checked = false`, `indeterminate = false`, clears form value and validity

### `v2/lib/src/components/FACE-NOTES.md`

Added AgCheckbox section covering:
- Why shadow DOM inputs don't submit to parent forms (key insight for the article)
- Delegation working on a checkbox input, not just text inputs
- The two-path sync pattern: event handler + `updated()` for programmatic changes
- Indeterminate form semantics (treated as unchecked / null)

## Key Design Notes

AgCheckbox is the first component that uses **both** patterns from the rollout: checkbox-pattern form value semantics (null when unchecked) from AgToggle, AND the delegation validation strategy from AgInput. The inner `<input type="checkbox">` handles `required` natively; `syncInnerInputValidity()` mirrors that state to `ElementInternals`.

## Test Plan

- [ ] Checked checkbox value appears in `FormData`; unchecked is excluded
- [ ] `form.reset()` unchecks the checkbox and clears indeterminate state
- [ ] `<fieldset disabled>` disables the checkbox
- [ ] `required` unchecked checkbox is invalid on form submit
- [ ] Programmatic `checkbox.checked = true` updates `FormData`
- [ ] All existing behavior (indeterminate, themes, sizes, ARIA) unchanged