### PR TITLE
Fix #305: AgSelect FACE — native form participation (Part of #274)

### DIFF
--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -444,6 +444,67 @@ restores both `checked` and `indeterminate` to false.
 
 ---
 
+## AgSelect: Multi-Value Submission and a Wider Helper
+
+AgSelect introduced two things the previous components hadn't needed.
+
+### The FormData Overload
+
+`setFormValue()` has three signatures. The one we've used so far takes a string (or null).
+For multi-select, a single string isn't enough — the user may have several options selected,
+all under the same key. `setFormValue()` also accepts a `FormData` object for exactly this:
+
+```typescript
+private _syncFormValue(): void {
+  if (!this.selectElement) return;
+  if (this.multiple) {
+    const formData = new FormData();
+    Array.from(this.selectElement.selectedOptions).forEach(opt => {
+      formData.append(this.name, opt.value);
+    });
+    this._internals.setFormValue(formData);
+  } else {
+    this._internals.setFormValue(this.selectElement.value || '');
+  }
+}
+```
+
+This matches how a native `<select multiple>` works: all selected values are submitted
+under the same `name` key, producing an array on the server side.
+
+It's also worth separating `_syncFormValue()` from `_syncValidity()` as distinct private
+methods. AgInput called them together in a single `_syncValidity()` call, but here the
+form value logic is substantive enough to merit its own name — and `formResetCallback`
+needs to call them independently anyway.
+
+### Widening syncInnerInputValidity
+
+The `syncInnerInputValidity` helper was typed for `HTMLInputElement | HTMLTextAreaElement`.
+An `HTMLSelectElement` has the same `.validity` and `.validationMessage` properties, so
+widening the type was a one-line change. The delegation strategy isn't tied to `<input>` —
+any native form element with a `ValidityState` can serve as the validation source.
+
+### Resetting to Default Selected
+
+`option.defaultSelected` reflects the `selected` attribute as originally parsed from HTML.
+It doesn't change when the user makes a selection. That makes it the correct anchor for
+`formResetCallback`:
+
+```typescript
+formResetCallback(): void {
+  if (this.selectElement) {
+    Array.from(this.selectElement.options).forEach(opt => (opt.selected = opt.defaultSelected));
+  }
+  this._syncFormValue();
+  this._internals.setValidity({});
+}
+```
+
+This matches native `<select>` behavior: form reset restores to however the HTML was
+originally written, not to "nothing selected."
+
+---
+
 ## What We Skipped and Why
 
 ### `formAssociatedCallback(form)`

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -23,22 +23,15 @@ implementation pattern.
 | Component | Issue | Notes |
 |-----------|-------|-------|
 | `AgInput` | #274 | Includes textarea mode; value submission, reset, disabled, constraint validation |
+| `AgToggle` | #301 | Direct validity (no inner input); null when unchecked; matches native checkbox semantics |
+| `AgCheckbox` | #303 | Delegation via inner `<input type="checkbox">`; null when unchecked; indeterminate treated as unchecked |
+| `AgSelect` | #305 | Delegation via inner `<select>`; `FormData` overload for multi-select; `defaultSelected` reset |
 
 ---
 
 ### 🔲 Pending — Straightforward Lift
 
-These components follow the same basic FACE pattern as `AgInput`.
-
-#### `AgCheckbox` (`components/Checkbox/`)
-
-- **Form value:** `"on"` when checked (matching native checkbox), or the `value` attribute
-- **Additional FACE work:**
-  - `get checked()` / `set checked()` getter-setter pair
-  - `formResetCallback()` restores `defaultChecked` state
-  - `click()` method to toggle checked state programmatically
-  - `setFormValue(checked ? value : null)` — null excludes it from FormData (native behavior)
-- **Complexity:** Medium. Checkbox semantics (indeterminate, defaultChecked) add surface area.
+These components follow the same basic FACE pattern as established above.
 
 #### `AgRadio` (`components/Radio/`)
 
@@ -49,20 +42,6 @@ These components follow the same basic FACE pattern as `AgInput`.
   - Click handling must uncheck sibling radios with the same `name` in the same form
 - **Complexity:** High. Radio group coordination across elements requires careful
   event-based communication or a shared group registry.
-
-#### `AgToggle` (`components/Toggle/`)
-
-- Functionally similar to a checkbox (on/off)
-- **Form value:** `"on"` or `null` (same as checkbox)
-- **Complexity:** Low-Medium. Same pattern as AgCheckbox.
-
-#### `AgSelect` (`components/Select/`)
-
-- **Form value:** The selected option's `value`
-- **Additional FACE work:**
-  - Multi-select: `setFormValue(FormData)` — use `FormData` overload to submit multiple values
-  - `formResetCallback()` restores `defaultValue` / `defaultSelected`
-- **Complexity:** Medium. Multi-select adds complexity.
 
 ---
 

--- a/v2/lib/src/components/Select/core/_Select.ts
+++ b/v2/lib/src/components/Select/core/_Select.ts
@@ -7,6 +7,7 @@ import {
   type LabelPosition,
 } from '../../../shared/form-control-utils';
 import { formControlStyles } from '../../../shared/form-control-styles';
+import { FaceMixin, syncInnerInputValidity } from '../../../shared/face-mixin';
 
 export type SelectSize = 'small' | 'large' | '';
 
@@ -47,7 +48,7 @@ export interface SelectProps {
  *
  * @fires change - Emitted when selection changes
  */
-export class Select extends LitElement implements SelectProps {
+export class Select extends FaceMixin(LitElement) implements SelectProps {
   @property({ type: String, reflect: true })
   public size: SelectSize = '';
 
@@ -56,9 +57,6 @@ export class Select extends LitElement implements SelectProps {
 
   @property({ type: Boolean, reflect: true })
   public disabled = false;
-
-  @property({ type: String })
-  public name = '';
 
   @property({ type: Number, attribute: 'multiple-size' })
   public multipleSize?: number;
@@ -103,6 +101,49 @@ export class Select extends LitElement implements SelectProps {
   @query('select')
   private selectElement!: HTMLSelectElement;
 
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Restores each option to its defaultSelected state (the `selected`
+   * attribute from the original HTML), then re-syncs the form value.
+   */
+  override formResetCallback(): void {
+    if (this.selectElement) {
+      Array.from(this.selectElement.options).forEach(opt => (opt.selected = opt.defaultSelected));
+    }
+    this._syncFormValue();
+    this._internals.setValidity({});
+  }
+
+  /**
+   * Sync the form value to ElementInternals.
+   * Single select: submits the selected value as a string.
+   * Multi-select: uses the FormData overload to submit all selected values
+   * under the same key (matching native <select multiple> behavior).
+   */
+  private _syncFormValue(): void {
+    if (!this.selectElement) return;
+    if (this.multiple) {
+      const formData = new FormData();
+      Array.from(this.selectElement.selectedOptions).forEach(opt => {
+        formData.append(this.name, opt.value);
+      });
+      this._internals.setFormValue(formData);
+    } else {
+      this._internals.setFormValue(this.selectElement.value || '');
+    }
+  }
+
+  /**
+   * Sync validity to ElementInternals by delegating to the inner <select>.
+   */
+  private _syncValidity(): void {
+    syncInnerInputValidity(this._internals, this.selectElement);
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
+
   protected firstUpdated() {
     // Ensure options are moved after first render
     this.handleSlotChange();
@@ -112,6 +153,10 @@ export class Select extends LitElement implements SelectProps {
     if (slotElement) {
       slotElement.addEventListener('slotchange', () => this.handleSlotChange());
     }
+
+    // FACE: set initial form value and sync validity after options are in place
+    this._syncFormValue();
+    this._syncValidity();
   }
 
   private handleSlotChange() {
@@ -275,6 +320,10 @@ export class Select extends LitElement implements SelectProps {
     } else {
       value = select.value;
     }
+
+    // FACE: sync form value and validity on every selection change
+    this._syncFormValue();
+    this._syncValidity();
 
     // Dual-dispatch: dispatchEvent + callback
     const changeEvent = new CustomEvent<SelectChangeEventDetail>('change', {

--- a/v2/lib/src/shared/face-mixin.ts
+++ b/v2/lib/src/shared/face-mixin.ts
@@ -40,11 +40,11 @@ type Constructor<T = {}> = new (...args: any[]) => T;
  * Call this on every `input` and `change` event, and once after `firstUpdated`.
  *
  * @param internals - The ElementInternals handle from attachInternals()
- * @param inputEl   - The inner native input or textarea element
+ * @param inputEl   - The inner native input, textarea, or select element
  */
 export function syncInnerInputValidity(
   internals: ElementInternals,
-  inputEl: HTMLInputElement | HTMLTextAreaElement | null | undefined
+  inputEl: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null | undefined
 ): void {
   if (!inputEl) return;
 


### PR DESCRIPTION
Part of epic #274.

## What Changed

### `v2/lib/src/shared/face-mixin.ts`
- Widened `syncInnerInputValidity` to accept `HTMLSelectElement` in addition to `HTMLInputElement | HTMLTextAreaElement` — the helper just reads `.validity` and `.validationMessage` which all native form elements expose

### `v2/lib/src/components/Select/core/_Select.ts`
- `Select extends FaceMixin(LitElement)`; local `name` property removed
- `_syncFormValue()`: single select submits `string`; multi-select builds a `FormData` object and calls `setFormValue(formData)` to submit all selected values under the same key
- `_syncValidity()`: delegates to inner `<select>` via `syncInnerInputValidity()`
- `formResetCallback()`: restores each `<option>` to `opt.defaultSelected`, then re-syncs form value and clears validity
- `handleChange()` and `firstUpdated()` wired to call `_syncFormValue()` + `_syncValidity()`

### `v2/lib/src/components/FACE-NOTES.md`
Added AgSelect section: the `FormData` overload for multi-select, widening the delegation helper, and `defaultSelected` reset behavior.

### `v2/lib/src/components/FACE-PLANNING.md`
Marked `AgToggle` (#301), `AgCheckbox` (#303), and `AgSelect` (#305) as completed in the rollout table. Removed them from the pending section.

## Test Plan

- [ ] Single select value appears in `FormData` on submit
- [ ] Multi-select: all selected values appear under the same key in `FormData`
- [ ] `form.reset()` restores the originally selected option(s)
- [ ] `<fieldset disabled>` disables the select
- [ ] `required` with no selection is invalid on submit
- [ ] All existing behavior (label positions, sizes, slotted options) unchanged