### PR TITLE
Fix #307: AgRadio FACE implementation

### DIFF
--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -1,6 +1,6 @@
 # FACE Implementation Notes
 
-_Working notes captured during Issues #274 (AgInput) and #301 (AgToggle) and ongoing rollout._
+_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), and ongoing rollout._
 _This file is the content source for a future article on implementing FACE in web components._
 
 ---
@@ -269,7 +269,7 @@ place visually.
 This gives us all of HTML5 constraint validation for free. New constraint types added to
 the spec later will also just work.
 
-### Direct Implementation (AgToggle, AgCheckbox, AgRadio, ...)
+### Direct Implementation (AgToggle, ...)
 
 `AgToggle` uses `<button role="switch">` internally. No inner `<input>` to delegate to.
 So we implement `_syncValidity()` directly against the component's own state:
@@ -596,6 +596,71 @@ Both are useful. Option A covers more ground (plain HTML, all frameworks, runtim
 messages). Option B is the nicer API in React/Vue. The cleanest path is probably Option B
 as the primary API with Option A available for cases that need runtime control. Decision
 deferred until the component rollout is complete.
+
+---
+
+## AgRadio: Group Coordination for Free
+
+AgRadio was listed as high complexity in the planning document. The concern was that radio
+groups require multiple elements to coordinate — when one is checked, the others must become
+unchecked and their FACE state updated accordingly. With native `<input type="radio">`, the
+browser handles this automatically. With elements in separate shadow DOM trees, it doesn't.
+
+The actual implementation was simpler than expected.
+
+### How Group Coordination Works
+
+AgRadio already had `uncheckOtherRadiosInGroup()`, which walks the DOM to find sibling
+`ag-radio` elements with the same `name` and sets `sibling.checked = false` on each.
+
+That's a Lit `@property` assignment. Lit detects the property change and calls `updated()`.
+We wire `_syncFormValue()` and `_syncValidity()` inside `updated()` whenever `checked`
+changes:
+
+```typescript
+override updated(changedProperties: Map<string, unknown>) {
+  super.updated(changedProperties);
+  if (changedProperties.has('checked')) {
+    this._syncFormValue();
+    this._syncValidity();
+  }
+}
+```
+
+When the checked radio calls `uncheckOtherRadiosInGroup()`, each sibling's `checked`
+property goes to `false`. Each sibling's `updated()` fires. Each sibling calls
+`_syncFormValue()` with `null`. Their FACE state is cleared automatically.
+
+No explicit "notify siblings to sync FACE" code needed anywhere. Lit's reactive property
+system is the coordination bus.
+
+### Keyboard Navigation Is Also Covered
+
+Arrow key navigation in `handleKeyDown` sets `nextRadio.checked = true` and then calls
+`nextRadio.uncheckOtherRadiosInGroup()`. Same chain: property change, `updated()` fires
+on the target, then on each sibling. FACE state follows the keyboard without any extra calls.
+
+### Delegation Works Here Too
+
+Because AgRadio renders an inner `<input type="radio">`, we use the delegation strategy
+for validity:
+
+```typescript
+private _syncValidity(): void {
+  syncInnerInputValidity(this._internals, this.inputRef);
+}
+```
+
+The browser's own required validation for radio groups (at least one radio with the name
+must be checked) applies through the inner input.
+
+### Form Value: One Contributor Per Group
+
+Each AgRadio element is form-associated independently. They all share a `name` but each
+calls `setFormValue()` on its own `_internals`. When a radio is checked, it submits
+`this.value`. When unchecked, it passes `null` — which excludes it from `FormData`. The
+result is exactly what a native radio group produces: only the checked radio's value
+appears in the submitted form data.
 
 ---
 

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -26,22 +26,7 @@ implementation pattern.
 | `AgToggle` | #301 | Direct validity (no inner input); null when unchecked; matches native checkbox semantics |
 | `AgCheckbox` | #303 | Delegation via inner `<input type="checkbox">`; null when unchecked; indeterminate treated as unchecked |
 | `AgSelect` | #305 | Delegation via inner `<select>`; `FormData` overload for multi-select; `defaultSelected` reset |
-
----
-
-### 🔲 Pending — Straightforward Lift
-
-These components follow the same basic FACE pattern as established above.
-
-#### `AgRadio` (`components/Radio/`)
-
-- **Form value:** The `value` attribute of the checked radio within a group
-- **Additional FACE work:**
-  - Radio groups share a `name` — only the checked radio submits its value
-  - `formResetCallback()` must restore `defaultChecked`
-  - Click handling must uncheck sibling radios with the same `name` in the same form
-- **Complexity:** High. Radio group coordination across elements requires careful
-  event-based communication or a shared group registry.
+| `AgRadio` | #307 | Delegation via inner `<input type="radio">`; group FACE sync via Lit `updated()` reactive chain |
 
 ---
 
@@ -102,29 +87,14 @@ These components are not form controls and do not need FACE:
 
 ## Implementation Order (Recommended)
 
-1. `AgToggle` — lowest complexity, establishes checkbox-like FACE pattern
-2. `AgCheckbox` — medium complexity, needed before AgRadio
-3. `AgSelect` — medium complexity, high usage in forms
-4. `AgRadio` — high complexity (group coordination), block on AgCheckbox
+1. ✅ `AgToggle` — lowest complexity, establishes checkbox-like FACE pattern
+2. ✅ `AgCheckbox` — medium complexity, needed before AgRadio
+3. ✅ `AgSelect` — medium complexity, high usage in forms
+4. ✅ `AgRadio` — group coordination via Lit reactive chain (simpler than anticipated)
 5. `AgSlider` — medium complexity, self-contained
 6. `AgRating` — medium complexity
 7. `AgSelectionButton` / `AgSelectionCard` — depends on Radio/Checkbox patterns
 8. `AgCombobox` — high complexity, requires UX decision on free-text vs constrained
-
----
-
-## Notes on Radio Group Coordination
-
-AgRadio groups require all radios with the same `name` in the same form to behave
-as a group — clicking one unchecks the others. Native `<input type="radio">` handles
-this automatically. With FACE:
-
-- Option 1: Walk the DOM on click to find siblings with matching `name` + `form`
-- Option 2: Use a shared `Map<string, Set<AgRadio>>` keyed on `[formId]:[name]`, updated
-  via `formAssociatedCallback` / `disconnectedCallback`
-
-Option 1 is simpler; Option 2 is more efficient for large forms. This decision should
-be documented in a `Radio/FACE-NOTES.md` as part of the AgRadio issue.
 
 ---
 

--- a/v2/lib/src/components/Radio/core/_Radio.ts
+++ b/v2/lib/src/components/Radio/core/_Radio.ts
@@ -5,6 +5,7 @@ import {
   createFormControlIds,
   buildAriaDescribedBy,
 } from '../../../shared/form-control-utils';
+import { FaceMixin, syncInnerInputValidity } from '../../../shared/face-mixin';
 
 
 export type RadioSize = 'small' | 'medium' | 'large';
@@ -96,7 +97,7 @@ export interface RadioProps {
   onChange?: (event: RadioChangeEvent) => void;
 }
 
-export class AgRadio extends LitElement implements RadioProps {
+export class AgRadio extends FaceMixin(LitElement) implements RadioProps {
   static override styles = [
     formControlStyles,
     css`
@@ -287,9 +288,6 @@ export class AgRadio extends LitElement implements RadioProps {
   ];
 
   @property({ type: String, reflect: true })
-  name = '';
-
-  @property({ type: String, reflect: true })
   value = '';
 
   @property({ type: Boolean, reflect: true })
@@ -336,12 +334,67 @@ export class AgRadio extends LitElement implements RadioProps {
   // Stable IDs for form control elements (created once)
   private _ids = createFormControlIds('ag-radio');
 
+  private inputRef?: HTMLInputElement;
+
   // Event callback props
   @property({ attribute: false })
   onClick?: (event: MouseEvent) => void;
 
   @property({ attribute: false })
   onChange?: (event: RadioChangeEvent) => void;
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Sync the form value to ElementInternals.
+   * Submits this radio's value when checked, or null when unchecked.
+   * Each radio in the group reports independently; only the checked one
+   * contributes a value, matching native radio behavior.
+   */
+  private _syncFormValue(): void {
+    this._internals.setFormValue(this.checked ? this.value : null);
+  }
+
+  /**
+   * Sync validity to ElementInternals by delegating to the inner
+   * <input type="radio">. The required constraint is met when any radio
+   * in the group is checked; the browser handles this natively.
+   */
+  private _syncValidity(): void {
+    syncInnerInputValidity(this._internals, this.inputRef);
+  }
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Restores checked to false and clears the form value.
+   */
+  override formResetCallback(): void {
+    this.checked = false;
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
+
+  override firstUpdated() {
+    this.inputRef = this.shadowRoot?.querySelector('.radio-input') as HTMLInputElement;
+
+    // FACE: set initial form value and sync validity after first render
+    this._syncFormValue();
+    this._syncValidity();
+  }
+
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+
+    // FACE: sync form value and validity for programmatic changes to checked.
+    // This fires when uncheckOtherRadiosInGroup() sets sibling.checked = false,
+    // so group FACE state stays synchronized without any explicit coordination.
+    if (changedProperties.has('checked')) {
+      this._syncFormValue();
+      this._syncValidity();
+    }
+  }
 
   private handleClick(e: MouseEvent) {
     if (this.onClick) {
@@ -445,6 +498,10 @@ export class AgRadio extends LitElement implements RadioProps {
     const input = e.target as HTMLInputElement;
     const wasChecked = this.checked;
     this.checked = input.checked;
+
+    // FACE: sync form value and validity on user interaction
+    this._syncFormValue();
+    this._syncValidity();
 
     // Radio group coordination: When this radio is checked, uncheck all other radios with the same name
     // This is necessary because native radios in separate shadow DOMs don't coordinate automatically


### PR DESCRIPTION
Closes #307

## What Changed

Applied `FaceMixin` to `AgRadio` so radio groups participate natively in HTML forms.

### Key files
- `v2/lib/src/components/Radio/core/_Radio.ts` — FACE applied
- `v2/lib/src/components/FACE-NOTES.md` — AgRadio section added
- `v2/lib/src/components/FACE-PLANNING.md` — AgRadio moved to completed

### How group coordination works

The planning doc flagged AgRadio as high complexity because of group state synchronization.
It turned out simpler than expected. `uncheckOtherRadiosInGroup()` already walks the DOM
and sets `sibling.checked = false`. That's a Lit `@property` assignment. Lit calls
`updated()`. We wire `_syncFormValue()` in `updated()` when `checked` changes. Sibling
FACE state clears automatically through the reactive property chain — no explicit
cross-element FACE coordination needed.

Keyboard navigation (arrow keys) follows the same path: `nextRadio.checked = true`
triggers `updated()` on the target, `uncheckOtherRadiosInGroup()` clears siblings.

### Delegation strategy

Uses `syncInnerInputValidity()` — same as AgCheckbox and AgSelect. The inner
`<input type="radio">` runs native required validation; we mirror it into ElementInternals.

### Part of epic
Issue #274 tracks the full FACE rollout. Components completed so far:
AgInput (#274), AgToggle (#301), AgCheckbox (#303), AgSelect (#305), AgRadio (#307).