### PR TITLE
Fix #310: AgSlider FACE implementation

### DIFF
--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -1,6 +1,6 @@
 # FACE Implementation Notes
 
-_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), and ongoing rollout._
+_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), and ongoing rollout._
 _This file is the content source for a future article on implementing FACE in web components._
 
 ---
@@ -694,3 +694,65 @@ appears in the submitted form data.
 - [ ] `CustomStateSet` via `_internals.states` for CSS pseudo-class support (`:--checked`, `:--invalid`, etc.)
 - [ ] `_parentDisabled` refinement for `formDisabledCallback` to avoid conflict with local disabled attribute
 - [ ] Apply FACE to remaining components per `FACE-PLANNING.md`
+
+---
+
+## AgSlider: Migrating Hand-Rolled FACE to FaceMixin
+
+AgSlider was different from the other components — it already had partial FACE
+infrastructure written by hand. `static formAssociated = true`, `attachInternals()`,
+`_updateFormValue()`, and the `form`/`validity` getters were all already there.
+
+The issue was that it didn't use FaceMixin, so it was missing `formDisabledCallback`
+(fieldset disabled propagation) and `formResetCallback` (form.reset() support), and it
+never set its initial form value at first render.
+
+### What the Migration Looked Like
+
+Most of the work was deleting code: `static formAssociated`, the private `_internals`
+field, `attachInternals()` from the constructor, the `name` property declaration, and
+all six hand-rolled FACE getters/methods. FaceMixin provides all of it.
+
+Then we added the two missing pieces:
+
+```typescript
+override firstUpdated() {
+  this._defaultValue = Array.isArray(this.value)
+    ? ([...this.value] as [number, number])
+    : this.value;
+  this._updateFormValue();
+}
+
+override formResetCallback(): void {
+  this.value = Array.isArray(this._defaultValue)
+    ? ([...this._defaultValue] as [number, number])
+    : this._defaultValue;
+  this._updateFormValue();
+}
+```
+
+`formDisabledCallback` comes free from FaceMixin — sets `this.disabled` from a `<fieldset
+disabled>` ancestor, same as every other FACE component.
+
+### Dual Slider Form Value
+
+The existing `_updateFormValue()` already handled dual mode correctly using the FormData
+overload — both min and max values submitted under the same `name` key. No changes needed
+to that logic.
+
+### Tracking Default Value
+
+Sliders can have an initial value set by the consumer (`value="75"` or `value="[25, 75]"`
+for dual). To restore the right value on form reset, we capture `this.value` at
+`firstUpdated` — after the component has processed its initial properties — and store it
+in `_defaultValue`.
+
+For dual mode, the array is shallow-copied to avoid aliasing bugs when the live `value`
+changes.
+
+### What We Left Alone
+
+The existing `_updateFormValue()` always calls `this._internals.setValidity({})`. For a
+range input, this is correct in practice: the slider UI always clamps values between min
+and max, so the underlying constraints are never violated. Range constraint validation
+(`rangeUnderflow`, `rangeOverflow`, `stepMismatch`) can be added in a follow-up if needed.

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -27,6 +27,7 @@ implementation pattern.
 | `AgCheckbox` | #303 | Delegation via inner `<input type="checkbox">`; null when unchecked; indeterminate treated as unchecked |
 | `AgSelect` | #305 | Delegation via inner `<select>`; `FormData` overload for multi-select; `defaultSelected` reset |
 | `AgRadio` | #307 | Delegation via inner `<input type="radio">`; group FACE sync via Lit `updated()` reactive chain |
+| `AgSlider` | #310 | Migrated from hand-rolled FACE to FaceMixin; `firstUpdated` captures default; dual mode uses FormData overload |
 
 ---
 
@@ -40,14 +41,6 @@ implementation pattern.
   - Two modes (free-text vs constrained select) require different validity semantics
 - **Complexity:** High. The UX contract between free-text and option selection affects
   what "valid" means, which must be documented before implementing.
-
-#### `AgSlider` (`components/Slider/`)
-
-- **Form value:** Current numeric value as a string
-- **Additional FACE work:**
-  - `min` / `max` / `step` constraint validation via `setValidity({ rangeUnderflow: true })` etc.
-  - `formResetCallback()` restores `defaultValue`
-- **Complexity:** Medium.
 
 ---
 
@@ -91,7 +84,7 @@ These components are not form controls and do not need FACE:
 2. ✅ `AgCheckbox` — medium complexity, needed before AgRadio
 3. ✅ `AgSelect` — medium complexity, high usage in forms
 4. ✅ `AgRadio` — group coordination via Lit reactive chain (simpler than anticipated)
-5. `AgSlider` — medium complexity, self-contained
+5. ✅ `AgSlider` — migrated hand-rolled FACE to FaceMixin; added firstUpdated + formResetCallback
 6. `AgRating` — medium complexity
 7. `AgSelectionButton` / `AgSelectionCard` — depends on Radio/Checkbox patterns
 8. `AgCombobox` — high complexity, requires UX decision on free-text vs constrained

--- a/v2/lib/src/components/Slider/core/_Slider.ts
+++ b/v2/lib/src/components/Slider/core/_Slider.ts
@@ -17,6 +17,7 @@ import {
   type LabelPosition,
 } from '../../../shared/form-control-utils';
 import { formControlStyles } from '../../../shared/form-control-styles';
+import { FaceMixin } from '../../../shared/face-mixin';
 
 // Props interface following INTERFACE_STANDARDS.md
 export interface SliderProps {
@@ -72,9 +73,8 @@ export interface SliderProps {
 /**
  * AgSlider - Foundation slider component with single/dual range support
  */
-export class AgSlider extends LitElement implements SliderProps {
-  static formAssociated = true;
-  static styles = [
+export class AgSlider extends FaceMixin(LitElement) implements SliderProps {
+  static override styles = [
     formControlStyles,
     css`
     :host {
@@ -427,8 +427,8 @@ export class AgSlider extends LitElement implements SliderProps {
   `,
   ];
 
-  // Form association
-  private _internals: ElementInternals;
+  // Default value captured at firstUpdated for formResetCallback
+  private _defaultValue: number | [number, number] = 0;
 
   // Form control IDs
   private _sliderId: string;
@@ -453,7 +453,6 @@ export class AgSlider extends LitElement implements SliderProps {
 
   constructor() {
     super();
-    this._internals = this.attachInternals();
 
     // Initialize form control IDs
     const ids = createFormControlIds('slider');
@@ -484,7 +483,6 @@ export class AgSlider extends LitElement implements SliderProps {
     this.invalid = false;
     this.errorMessage = '';
     this.helpText = '';
-    this.name = '';
     this.showTooltip = false;
     this.showTicks = false;
     this.tickStep = 25;
@@ -577,12 +575,6 @@ export class AgSlider extends LitElement implements SliderProps {
   declare helpText: string;
 
   /**
-   * Form association
-   */
-  @property({ type: String, reflect: true })
-  declare name: string;
-
-  /**
    * Display options
    */
   @property({ type: Boolean, attribute: 'show-tooltip' })
@@ -626,21 +618,6 @@ export class AgSlider extends LitElement implements SliderProps {
 
   @query('.ag-slider__live-region')
   private _liveRegion?: HTMLElement;
-
-  /**
-   * Form value handling
-   */
-  get form() { return this._internals.form; }
-  
-  get validity() { return this._internals.validity; }
-  
-  get validationMessage() { return this._internals.validationMessage; }
-  
-  get willValidate() { return this._internals.willValidate; }
-
-  checkValidity() { return this._internals.checkValidity(); }
-  
-  reportValidity() { return this._internals.reportValidity(); }
 
   /**
    * Property validation
@@ -691,6 +668,29 @@ export class AgSlider extends LitElement implements SliderProps {
       }
     }
   }
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  override firstUpdated() {
+    // Capture default value for formResetCallback, then set initial form value
+    this._defaultValue = Array.isArray(this.value)
+      ? ([...this.value] as [number, number])
+      : this.value;
+    this._updateFormValue();
+  }
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Restores the slider to the value it had on first render.
+   */
+  override formResetCallback(): void {
+    this.value = Array.isArray(this._defaultValue)
+      ? ([...this._defaultValue] as [number, number])
+      : this._defaultValue;
+    this._updateFormValue();
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
 
   /**
    * Update form value when component value changes


### PR DESCRIPTION
Closes #310

## What Changed

AgSlider already had partial FACE infrastructure hand-rolled. This migrates it to `FaceMixin` and adds the missing lifecycle methods.

### Removed (replaced by FaceMixin)
- `static formAssociated = true`
- `private _internals: ElementInternals`
- `this.attachInternals()` from constructor
- `name` property declaration and constructor init
- `get form/validity/validationMessage/willValidate`, `checkValidity()`, `reportValidity()`

### Added
- `firstUpdated()` — captures `_defaultValue` and sets initial form value
- `formResetCallback()` — restores slider to initial value on form reset
- `formDisabledCallback()` — free from FaceMixin (fieldset disabled propagation)

### Dual mode

The existing `_updateFormValue()` already handled dual mode correctly with the `FormData` overload. No changes to that logic.

### Part of epic
Issue #274 tracks the full FACE rollout. Components completed: AgInput, AgToggle, AgCheckbox, AgSelect, AgRadio, AgSlider.