### PR TITLE
Fix #312: AgRating FACE implementation

### DIFF
--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -1,6 +1,6 @@
 # FACE Implementation Notes
 
-_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), and ongoing rollout._
+_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), #312 (AgRating), and ongoing rollout._
 _This file is the content source for a future article on implementing FACE in web components._
 
 ---
@@ -756,3 +756,31 @@ The existing `_updateFormValue()` always calls `this._internals.setValidity({})`
 range input, this is correct in practice: the slider UI always clamps values between min
 and max, so the underlying constraints are never violated. Range constraint validation
 (`rangeUnderflow`, `rangeOverflow`, `stepMismatch`) can be added in a follow-up if needed.
+
+---
+
+## AgRating: Direct Validity Without an Inner Input
+
+AgRating uses a custom `role="slider"` div for its interactive star widget — no inner
+`<input>`. Like AgToggle, that means the direct validation approach: implement
+`_syncValidity()` against component state rather than delegating to a native element.
+
+A rating of `0` means nothing selected (the initial state, also reachable via `allowClear`).
+That's the only case where `required` fires:
+
+```typescript
+private _syncValidity(): void {
+  if (this.required && this.value === 0) {
+    this._internals.setValidity({ valueMissing: true }, 'Please select a rating.');
+  } else {
+    this._internals.setValidity({});
+  }
+}
+```
+
+For form value, `0` submits as `null` (absent from FormData) to match the convention
+established by checkbox/toggle — "nothing selected" means absent, not an empty string.
+Any positive value submits as a string (`"3"`, `"3.5"` for half-star precision).
+
+`commitValue()` is the single path all user interactions flow through (clicks, pointer up,
+keyboard). Wiring FACE sync there plus in `updated()` for programmatic changes covers both paths.

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -28,6 +28,7 @@ implementation pattern.
 | `AgSelect` | #305 | Delegation via inner `<select>`; `FormData` overload for multi-select; `defaultSelected` reset |
 | `AgRadio` | #307 | Delegation via inner `<input type="radio">`; group FACE sync via Lit `updated()` reactive chain |
 | `AgSlider` | #310 | Migrated from hand-rolled FACE to FaceMixin; `firstUpdated` captures default; dual mode uses FormData overload |
+| `AgRating` | #312 | Direct validity (no inner input); null when value=0; positive values submit as string |
 
 ---
 
@@ -85,7 +86,7 @@ These components are not form controls and do not need FACE:
 3. ✅ `AgSelect` — medium complexity, high usage in forms
 4. ✅ `AgRadio` — group coordination via Lit reactive chain (simpler than anticipated)
 5. ✅ `AgSlider` — migrated hand-rolled FACE to FaceMixin; added firstUpdated + formResetCallback
-6. `AgRating` — medium complexity
+6. ✅ `AgRating` — direct validity; null when value=0
 7. `AgSelectionButton` / `AgSelectionCard` — depends on Radio/Checkbox patterns
 8. `AgCombobox` — high complexity, requires UX decision on free-text vs constrained
 

--- a/v2/lib/src/components/Rating/core/_Rating.ts
+++ b/v2/lib/src/components/Rating/core/_Rating.ts
@@ -8,6 +8,7 @@ import {
   type LabelPosition,
 } from '../../../shared/form-control-utils';
 import { formControlStyles } from '../../../shared/form-control-styles';
+import { FaceMixin } from '../../../shared/face-mixin';
 
 // Event detail interfaces
 export interface RatingChangeEventDetail {
@@ -53,7 +54,7 @@ export interface RatingProps {
 
 let uniqueIdCounter = 0;
 
-export class AgRating extends LitElement {
+export class AgRating extends FaceMixin(LitElement) {
   private uniqueId = ++uniqueIdCounter; // Unique ID for clip paths in half-star rendering
 
   // Form control IDs
@@ -83,9 +84,6 @@ export class AgRating extends LitElement {
 
   @property({ type: String, reflect: true })
   declare size: RatingSize; // Size: small, medium, large
-
-  @property({ type: String })
-  declare name: string; // Form integration name
 
   // Form control properties
   @property({ type: String })
@@ -141,7 +139,6 @@ export class AgRating extends LitElement {
     this.allowClear = false;
     this.variant = '';
     this.size = 'md';
-    this.name = '';
     this.label = '';
     this.labelHidden = false;
     this.noLabel = false;
@@ -153,6 +150,53 @@ export class AgRating extends LitElement {
     this.handlePointerUp = this.handlePointerUp.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
   }
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Sync the form value to ElementInternals.
+   * Submits the numeric rating as a string, or null when value is 0 (no rating).
+   */
+  private _syncFormValue(): void {
+    this._internals.setFormValue(this.value > 0 ? String(this.value) : null);
+  }
+
+  /**
+   * Sync validity. No inner input to delegate to, so we implement required
+   * directly: a rating of 0 with required=true is valueMissing.
+   */
+  private _syncValidity(): void {
+    if (this.required && this.value === 0) {
+      this._internals.setValidity({ valueMissing: true }, 'Please select a rating.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  override firstUpdated() {
+    this._syncFormValue();
+    this._syncValidity();
+  }
+
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+    if (changedProperties.has('value')) {
+      this._syncFormValue();
+      this._syncValidity();
+    }
+  }
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Restores rating to 0 (no selection).
+   */
+  override formResetCallback(): void {
+    this.value = 0;
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
 
   connectedCallback() {
     super.connectedCallback();
@@ -558,6 +602,11 @@ export class AgRating extends LitElement {
   private commitValue(newValue: number, oldValue: number) {
     const normalized = this.roundToPrecision(newValue);
     this.value = normalized;
+
+    // FACE: sync form value and validity on user interaction
+    this._syncFormValue();
+    this._syncValidity();
+
     const changeEvent = new CustomEvent<RatingChangeEventDetail>('rating-change', {
       detail: { oldValue, newValue: normalized },
       bubbles: true,


### PR DESCRIPTION
Closes #312

Part of the FACE rollout (#274). AgRating has no inner input so uses direct validity (same pattern as AgToggle). Value 0 = no rating selected → null in FormData. All interactions go through `commitValue()`; `updated()` handles programmatic changes.