### PR TITLE
Fix #314: AgSelectionButtonGroup + AgSelectionCardGroup FACE

### DIFF
--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -1,6 +1,6 @@
 # FACE Implementation Notes
 
-_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), #312 (AgRating), and ongoing rollout._
+_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), #312 (AgRating), #314 (AgSelectionButtonGroup, AgSelectionCardGroup), and ongoing rollout._
 _This file is the content source for a future article on implementing FACE in web components._
 
 ---
@@ -784,3 +784,53 @@ Any positive value submits as a string (`"3"`, `"3.5"` for half-star precision).
 
 `commitValue()` is the single path all user interactions flow through (clicks, pointer up,
 keyboard). Wiring FACE sync there plus in `updated()` for programmatic changes covers both paths.
+
+---
+
+## AgSelectionButtonGroup + AgSelectionCardGroup: FACE on the Coordinator
+
+SelectionButton and SelectionCard are composite widgets — individual items inside a
+coordinating group element. The question is which element should be form-associated.
+
+The answer is the **group**, not the individual items. The group is the element that knows
+the `name`, the `type` (radio vs checkbox), and the full set of selected values. Individual
+buttons/cards don't have names of their own — the group sets `_name` on them internally.
+
+This is the same model as a native `<select>`: one form control that contains many
+`<option>` elements. The options aren't form-associated; the select is.
+
+### Radio vs Checkbox Mode
+
+Both groups have a `type` property: `'radio'` or `'checkbox'`. This determines the
+form value semantics, just like AgSelect's `multiple` property:
+
+```typescript
+private _syncFormValue(): void {
+  const selected = this._getSelectedValues();
+  if (this.type === 'radio') {
+    this._internals.setFormValue(selected.length > 0 ? selected[0] : null);
+  } else {
+    if (selected.length === 0) {
+      this._internals.setFormValue(null);
+    } else {
+      const formData = new FormData();
+      selected.forEach(val => formData.append(this.name, val));
+      this._internals.setFormValue(formData);
+    }
+  }
+}
+```
+
+When nothing is selected, `null` keeps the field absent from FormData. For checkbox mode
+with selections, the FormData overload submits all values under the same `name` key.
+
+### Form Reset
+
+`formResetCallback` clears `_internalSelectedValues`, sets form value to null, and calls
+`_syncChildCards/Buttons()` so the UI reflects the cleared state immediately.
+
+### What Was Left Out
+
+Neither group currently has a `required` property in its public API. Constraint
+validation (`valueMissing`) can be added in a follow-up when `required` is added to
+the group's prop interface. For now, `_syncValidity()` always reports valid.

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -29,6 +29,8 @@ implementation pattern.
 | `AgRadio` | #307 | Delegation via inner `<input type="radio">`; group FACE sync via Lit `updated()` reactive chain |
 | `AgSlider` | #310 | Migrated from hand-rolled FACE to FaceMixin; `firstUpdated` captures default; dual mode uses FormData overload |
 | `AgRating` | #312 | Direct validity (no inner input); null when value=0; positive values submit as string |
+| `AgSelectionButtonGroup` | #314 | FACE on group (not items); radio=string, checkbox=FormData overload; formReset clears internal state |
+| `AgSelectionCardGroup` | #314 | Same pattern as AgSelectionButtonGroup |
 
 ---
 
@@ -42,22 +44,6 @@ implementation pattern.
   - Two modes (free-text vs constrained select) require different validity semantics
 - **Complexity:** High. The UX contract between free-text and option selection affects
   what "valid" means, which must be documented before implementing.
-
----
-
-### 🔲 Pending — Composite / Multi-Value Components
-
-These have multiple internal controls or submit multiple values.
-
-#### `AgRating` (`components/Rating/`)
-
-- **Form value:** The numeric rating (e.g. `"3"`)
-- **Complexity:** Low-Medium. Keyboard interaction (arrow keys) must update form value.
-
-#### `AgSelectionButton` / `AgSelectionCard` (`components/SelectionButton/`, `components/SelectionCard/`)
-
-- These function like radio buttons or checkboxes depending on configuration
-- **Complexity:** Medium. Must mirror the checked/unchecked pattern of AgCheckbox/AgRadio.
 
 ---
 
@@ -87,7 +73,7 @@ These components are not form controls and do not need FACE:
 4. ✅ `AgRadio` — group coordination via Lit reactive chain (simpler than anticipated)
 5. ✅ `AgSlider` — migrated hand-rolled FACE to FaceMixin; added firstUpdated + formResetCallback
 6. ✅ `AgRating` — direct validity; null when value=0
-7. `AgSelectionButton` / `AgSelectionCard` — depends on Radio/Checkbox patterns
+7. ✅ `AgSelectionButtonGroup` / `AgSelectionCardGroup` — FACE on group element; radio/checkbox via FormData overload
 8. `AgCombobox` — high complexity, requires UX decision on free-text vs constrained
 
 ---

--- a/v2/lib/src/components/SelectionButtonGroup/core/_SelectionButtonGroup.ts
+++ b/v2/lib/src/components/SelectionButtonGroup/core/_SelectionButtonGroup.ts
@@ -13,6 +13,7 @@
 
 import { LitElement, html, css, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { FaceMixin } from '../../../shared/face-mixin';
 import type { AgSelectionButton, SelectionButtonTheme, SelectionButtonSize, SelectionButtonShape } from '../../SelectionButton/core/_SelectionButton.js';
 
 export type SelectionButtonType = 'radio' | 'checkbox';
@@ -56,7 +57,7 @@ export interface SelectionButtonGroupProps {
   onSelectionChange?: (event: SelectionButtonChangeEvent) => void;
 }
 
-export class AgSelectionButtonGroup extends LitElement implements SelectionButtonGroupProps {
+export class AgSelectionButtonGroup extends FaceMixin(LitElement) implements SelectionButtonGroupProps {
   static override styles = css`
     :host {
       display: block;
@@ -99,9 +100,6 @@ export class AgSelectionButtonGroup extends LitElement implements SelectionButto
   @property({ type: String, reflect: true })
   declare type: SelectionButtonType;
 
-  @property({ type: String, reflect: true })
-  declare name: string;
-
   @property({ type: String })
   declare legend: string;
 
@@ -136,7 +134,6 @@ export class AgSelectionButtonGroup extends LitElement implements SelectionButto
   constructor() {
     super();
     this.type = 'radio';
-    this.name = '';
     this.legend = '';
     this.legendHidden = false;
     this.theme = '';
@@ -163,6 +160,50 @@ export class AgSelectionButtonGroup extends LitElement implements SelectionButto
     }
     return this._internalSelectedValues;
   }
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Sync the form value to ElementInternals.
+   * Radio: submits the selected value as a string, or null if nothing selected.
+   * Checkbox: submits all selected values via FormData overload.
+   */
+  private _syncFormValue(): void {
+    const selected = this._getSelectedValues();
+    if (this.type === 'radio') {
+      this._internals.setFormValue(selected.length > 0 ? selected[0] : null);
+    } else {
+      if (selected.length === 0) {
+        this._internals.setFormValue(null);
+      } else {
+        const formData = new FormData();
+        selected.forEach(val => formData.append(this.name, val));
+        this._internals.setFormValue(formData);
+      }
+    }
+  }
+
+  /**
+   * Sync validity to ElementInternals. Always valid — selection groups
+   * do not currently expose a required constraint. Extend in a follow-up
+   * when a required prop is added to the group API.
+   */
+  private _syncValidity(): void {
+    this._internals.setValidity({});
+  }
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Clears all selections and re-syncs child buttons.
+   */
+  override formResetCallback(): void {
+    this._internalSelectedValues = [];
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+    this._syncChildButtons();
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
 
   override connectedCallback() {
     super.connectedCallback();
@@ -193,10 +234,22 @@ export class AgSelectionButtonGroup extends LitElement implements SelectionButto
     ) {
       this._syncChildButtons();
     }
+
+    // FACE: sync for programmatic value/values changes
+    if (
+      changedProperties.has('value') ||
+      changedProperties.has('values') ||
+      changedProperties.has('_internalSelectedValues')
+    ) {
+      this._syncFormValue();
+      this._syncValidity();
+    }
   }
 
   override firstUpdated() {
     this._syncChildButtons();
+    this._syncFormValue();
+    this._syncValidity();
   }
 
   private _getButtons(): AgSelectionButton[] {
@@ -252,6 +305,10 @@ export class AgSelectionButtonGroup extends LitElement implements SelectionButto
 
     // Update internal state (for uncontrolled mode)
     this._internalSelectedValues = newSelectedValues;
+
+    // FACE: sync form value and validity on user interaction
+    this._syncFormValue();
+    this._syncValidity();
 
     // Dispatch event
     const changeEvent = new CustomEvent<SelectionButtonChangeEventDetail>('selection-change', {

--- a/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
+++ b/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
@@ -14,6 +14,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { AgSelectionCard } from '../../SelectionCard/core/_SelectionCard.js';
+import { FaceMixin } from '../../../shared/face-mixin';
 
 export type SelectionType = 'radio' | 'checkbox';
 export type SelectionCardGroupTheme = 'success' | 'info' | 'error' | 'warning' | 'monochrome' | '';
@@ -50,7 +51,7 @@ export interface SelectionCardGroupProps {
   onSelectionChange?: (event: SelectionChangeEvent) => void;
 }
 
-export class AgSelectionCardGroup extends LitElement implements SelectionCardGroupProps {
+export class AgSelectionCardGroup extends FaceMixin(LitElement) implements SelectionCardGroupProps {
   static override styles = css`
     :host {
       display: block;
@@ -93,9 +94,6 @@ export class AgSelectionCardGroup extends LitElement implements SelectionCardGro
   @property({ type: String, reflect: true })
   declare type: SelectionType;
 
-  @property({ type: String, reflect: true })
-  declare name: string;
-
   @property({ type: String })
   declare legend: string;
 
@@ -124,7 +122,6 @@ export class AgSelectionCardGroup extends LitElement implements SelectionCardGro
   constructor() {
     super();
     this.type = 'radio';
-    this.name = '';
     this.legend = '';
     this.legendHidden = false;
     this.theme = '';
@@ -149,6 +146,36 @@ export class AgSelectionCardGroup extends LitElement implements SelectionCardGro
     }
     return this._internalSelectedValues;
   }
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  private _syncFormValue(): void {
+    const selected = this._getSelectedValues();
+    if (this.type === 'radio') {
+      this._internals.setFormValue(selected.length > 0 ? selected[0] : null);
+    } else {
+      if (selected.length === 0) {
+        this._internals.setFormValue(null);
+      } else {
+        const formData = new FormData();
+        selected.forEach(val => formData.append(this.name, val));
+        this._internals.setFormValue(formData);
+      }
+    }
+  }
+
+  private _syncValidity(): void {
+    this._internals.setValidity({});
+  }
+
+  override formResetCallback(): void {
+    this._internalSelectedValues = [];
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+    this._syncChildCards();
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
 
   override connectedCallback() {
     super.connectedCallback();
@@ -177,10 +204,22 @@ export class AgSelectionCardGroup extends LitElement implements SelectionCardGro
     ) {
       this._syncChildCards();
     }
+
+    // FACE: sync for programmatic value/values changes
+    if (
+      changedProperties.has('value') ||
+      changedProperties.has('values') ||
+      changedProperties.has('_internalSelectedValues')
+    ) {
+      this._syncFormValue();
+      this._syncValidity();
+    }
   }
 
   override firstUpdated() {
     this._syncChildCards();
+    this._syncFormValue();
+    this._syncValidity();
   }
 
   private _getCards(): AgSelectionCard[] {
@@ -234,6 +273,10 @@ export class AgSelectionCardGroup extends LitElement implements SelectionCardGro
 
     // Update internal state (for uncontrolled mode)
     this._internalSelectedValues = newSelectedValues;
+
+    // FACE: sync form value and validity on user interaction
+    this._syncFormValue();
+    this._syncValidity();
 
     // Dispatch event
     const changeEvent = new CustomEvent<SelectionChangeEventDetail>('selection-change', {


### PR DESCRIPTION
Closes #314

## What Changed

Applied `FaceMixin` to `AgSelectionButtonGroup` and `AgSelectionCardGroup` (the group elements — not individual cards/buttons).

### Why the group, not the items

The group owns `name`, `type` (radio/checkbox), and the full selected values state. Individual items get `_name` assigned by the group. This matches the native `<select>` model.

### Radio vs checkbox

- Radio: `setFormValue(selectedValue || null)`
- Checkbox: `setFormValue(formData)` using the FormData overload — same as `AgSelect multiple`

### Form reset

Clears `_internalSelectedValues`, nulls the form value, and calls `_syncChildButtons/Cards()` so the UI updates immediately.

### What was left out

Neither group has a `required` property yet. `_syncValidity()` always reports valid for now. Can be extended in a follow-up when `required` is added to the group API.

### Part of epic
Issue #274 tracks the full FACE rollout. Only `AgCombobox` remains (high complexity, pending UX decision).