### PR TITLE
Fix #316: AgCombobox FACE implementation

### DIFF
--- a/v2/lib/src/components/Combobox/core/_Combobox.ts
+++ b/v2/lib/src/components/Combobox/core/_Combobox.ts
@@ -16,6 +16,7 @@
 
 import { LitElement, html, css, nothing } from 'lit';
 import { property, state, query } from 'lit/decorators.js';
+import { FaceMixin } from '../../../shared/face-mixin';
 import {
   createFormControlIds,
   buildAriaDescribedBy,
@@ -138,7 +139,7 @@ export interface ComboboxProps {
  * @csspart ag-combobox-help-text - Help text element
  * @csspart ag-combobox-error-message - Error message element
  */
-export class AgCombobox extends LitElement implements ComboboxProps {
+export class AgCombobox extends FaceMixin(LitElement) implements ComboboxProps {
   static styles = [
     formControlStyles,
     css`
@@ -746,6 +747,15 @@ export class AgCombobox extends LitElement implements ComboboxProps {
     }
   }
 
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+    // FACE: sync for programmatic value changes
+    if (changedProperties.has('value')) {
+      this._syncFormValue();
+      this._syncValidity();
+    }
+  }
+
   // Public methods
   focus() {
     this._inputElement?.focus();
@@ -876,6 +886,10 @@ export class AgCombobox extends LitElement implements ComboboxProps {
     this.dispatchEvent(selectEvent);
     this.onSelect?.(selectEvent);
 
+    // FACE: sync form value and validity after selection
+    this._syncFormValue();
+    this._syncValidity();
+
     // Dispatch change event (value is already updated by _selectionChanged)
     const changeEvent = new CustomEvent<ComboboxChangeEventDetail>('change', {
       detail: {
@@ -914,6 +928,10 @@ export class AgCombobox extends LitElement implements ComboboxProps {
     this._selectionChanged();
     this._activeIndex = -1;
 
+    // FACE: sync form value and validity on clear
+    this._syncFormValue();
+    this._syncValidity();
+
     // Dispatch change event
     const changeEvent = new CustomEvent<ComboboxChangeEventDetail>('change', {
       detail: {
@@ -926,6 +944,62 @@ export class AgCombobox extends LitElement implements ComboboxProps {
     this.dispatchEvent(changeEvent);
     this.onChange?.(changeEvent);
   }
+
+  // ─── FACE ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Sync the form value to ElementInternals.
+   * Single: submits the selected value string, or null if nothing selected.
+   * Multiple: submits all selected values via FormData overload.
+   * Typed text that hasn't been committed via selectOption() is never submitted.
+   */
+  private _syncFormValue(): void {
+    if (this.multiple) {
+      const selected = Array.isArray(this.value) ? this.value : [];
+      if (selected.length === 0) {
+        this._internals.setFormValue(null);
+      } else {
+        const formData = new FormData();
+        selected.forEach(val => formData.append(this.name, val));
+        this._internals.setFormValue(formData);
+      }
+    } else {
+      const val = typeof this.value === 'string' ? this.value : '';
+      this._internals.setFormValue(val || null);
+    }
+  }
+
+  /**
+   * Sync validity. Required with no selection = valueMissing.
+   */
+  private _syncValidity(): void {
+    const hasValue = this.multiple
+      ? (Array.isArray(this.value) && this.value.length > 0)
+      : !!(typeof this.value === 'string' && this.value);
+    if (this.required && !hasValue) {
+      this._internals.setValidity({ valueMissing: true }, 'Please select an option.');
+    } else {
+      this._internals.setValidity({});
+    }
+  }
+
+  override firstUpdated() {
+    this._syncFormValue();
+    this._syncValidity();
+  }
+
+  /**
+   * FACE lifecycle: called when the parent form is reset.
+   * Clears selection and re-syncs form value.
+   */
+  override formResetCallback(): void {
+    this._selectedOptions = [];
+    this._selectionChanged();
+    this._internals.setFormValue(null);
+    this._internals.setValidity({});
+  }
+
+  // ─── End FACE ─────────────────────────────────────────────────────────────
 
   // Private methods
   private _selectionChanged() {

--- a/v2/lib/src/components/FACE-NOTES.md
+++ b/v2/lib/src/components/FACE-NOTES.md
@@ -1,6 +1,6 @@
 # FACE Implementation Notes
 
-_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), #312 (AgRating), #314 (AgSelectionButtonGroup, AgSelectionCardGroup), and ongoing rollout._
+_Working notes captured during Issues #274 (AgInput), #301 (AgToggle), #303 (AgCheckbox), #305 (AgSelect), #307 (AgRadio), #310 (AgSlider), #312 (AgRating), #314 (AgSelectionButtonGroup, AgSelectionCardGroup), #316 (AgCombobox). FACE rollout complete.._
 _This file is the content source for a future article on implementing FACE in web components._
 
 ---
@@ -834,3 +834,45 @@ with selections, the FormData overload submits all values under the same `name` 
 Neither group currently has a `required` property in its public API. Constraint
 validation (`valueMissing`) can be added in a follow-up when `required` is added to
 the group's prop interface. For now, `_syncValidity()` always reports valid.
+
+---
+
+## AgCombobox: The "High Complexity" Component That Wasn't
+
+The planning doc flagged AgCombobox as high complexity with a note to defer until a UX
+decision was made: does typing into the input count as the form value, or only selecting?
+
+Reading the existing code answered it. There's no free-text mode. The component has two
+value-commit paths:
+
+1. `selectOption()` — user picks from the dropdown
+2. `clearSelection()` — user clicks the clear button
+
+Everything else (typing in the search input, arrow-keying through options) updates
+`_searchTerm` for filtering, but doesn't touch `this.value`. So the form value is
+unambiguously the selected option value(s), not whatever the user typed.
+
+### Implementation
+
+Single and multiple modes follow the same patterns as AgSelect and AgSelectionButtonGroup:
+
+- Single: `setFormValue(this.value || null)` — null if nothing selected
+- Multiple: FormData overload — all selected values under the same `name` key
+
+The `_syncFormValue()` and `_syncValidity()` calls go in both `selectOption()` and
+`clearSelection()`. The `updated()` hook handles programmatic changes to `this.value`.
+
+For `formResetCallback`, we call `clearSelection()` via its internals (`_selectedOptions = []`
+then `_selectionChanged()`), then explicitly null the form value and clear validity. The
+`_selectionChanged()` call also resets `_searchTerm` and `_displayLabel` so the input
+clears visually.
+
+### FACE Rollout Complete
+
+With AgCombobox, all form-capable components in AgnosticUI now participate natively in
+HTML forms. Every `ag-*` form control can be used inside a `<form>` tag and will:
+
+- Submit its value via `FormData` on form submit
+- Reset to default state on `form.reset()`
+- Reflect disabled state from `<fieldset disabled>` ancestors
+- Participate in constraint validation via `checkValidity()` / `reportValidity()`

--- a/v2/lib/src/components/FACE-PLANNING.md
+++ b/v2/lib/src/components/FACE-PLANNING.md
@@ -31,19 +31,7 @@ implementation pattern.
 | `AgRating` | #312 | Direct validity (no inner input); null when value=0; positive values submit as string |
 | `AgSelectionButtonGroup` | #314 | FACE on group (not items); radio=string, checkbox=FormData overload; formReset clears internal state |
 | `AgSelectionCardGroup` | #314 | Same pattern as AgSelectionButtonGroup |
-
----
-
-### 🔲 Pending — More Complex
-
-#### `AgCombobox` (`components/Combobox/`)
-
-- **Form value:** The committed input value or selected option value
-- **Additional FACE work:**
-  - Must decide: does typing into the input count as the form value, or only selecting?
-  - Two modes (free-text vs constrained select) require different validity semantics
-- **Complexity:** High. The UX contract between free-text and option selection affects
-  what "valid" means, which must be documented before implementing.
+| `AgCombobox` | #316 | Direct validity; no free-text mode — only `selectOption()`/`clearSelection()` commit values; single=string, multiple=FormData overload |
 
 ---
 
@@ -74,7 +62,7 @@ These components are not form controls and do not need FACE:
 5. ✅ `AgSlider` — migrated hand-rolled FACE to FaceMixin; added firstUpdated + formResetCallback
 6. ✅ `AgRating` — direct validity; null when value=0
 7. ✅ `AgSelectionButtonGroup` / `AgSelectionCardGroup` — FACE on group element; radio/checkbox via FormData overload
-8. `AgCombobox` — high complexity, requires UX decision on free-text vs constrained
+8. ✅ `AgCombobox` — no free-text mode exists; only `selectOption()`/`clearSelection()` commit values; simpler than anticipated
 
 ---
 


### PR DESCRIPTION
## Summary

- Applies `FaceMixin` to `AgCombobox` — the final form-associated component in the FACE rollout
- No free-text mode exists in AgCombobox: only `selectOption()` and `clearSelection()` commit values, so validity semantics are simpler than anticipated
- Single mode: submits selected value as string, or `null` when nothing selected
- Multiple mode: uses `FormData` overload (same pattern as `AgSelect` multi-select)
- `formResetCallback` clears `_selectedOptions` and re-syncs via `_selectionChanged()`
- Wired `_syncFormValue()` + `_syncValidity()` in `selectOption()`, `clearSelection()`, `firstUpdated()`, and `updated()` (for programmatic `value` changes)
- Updates `FACE-NOTES.md` with AgCombobox section + "FACE Rollout Complete" closing note
- Updates `FACE-PLANNING.md`: AgCombobox moved to completed table, pending section removed, item 8 marked ✅

## Test plan

- [ ] Single mode: selecting an option submits its value; clearing submits nothing
- [ ] Multiple mode: selected values appear as repeated fields in FormData
- [ ] `required` + no selection → `valueMissing` validity; selecting → clears validity
- [ ] `form.reset()` clears all selections via `formResetCallback`
- [ ] Programmatic `value` property change syncs form value without user interaction