### PR TITLE
Fix #325: add automated CLI publish workflow via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,67 @@
+name: Publish CLI to NPM
+
+on:
+  push:
+    tags:
+      - 'v2.*'
+
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+  contents: read
+
+jobs:
+  publish:
+    name: Build, test, and publish agnosticui-cli
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Validate tag matches package.json version
+        working-directory: v2/cli
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "❌ Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "✅ Version validated: $PKG_VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: v2/cli
+
+      - name: Build
+        run: npm run build
+        working-directory: v2/cli
+
+      - name: Test
+        run: npm test
+        working-directory: v2/cli
+
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [[ "$TAG_VERSION" == *"-"* ]]; then
+            echo "tag=alpha" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to NPM
+        run: npm publish --tag ${{ steps.dist-tag.outputs.tag }}
+        working-directory: v2/cli
+
+      - name: Point latest dist-tag to this release
+        if: steps.dist-tag.outputs.tag == 'alpha'
+        working-directory: v2/cli
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          npm dist-tag add agnosticui-cli@${PKG_VERSION} latest

--- a/v2/docs/CLI.md
+++ b/v2/docs/CLI.md
@@ -385,15 +385,13 @@ git push origin master
 
 ### 6. Publish to npm
 
-**Verify npm Login:**
+**agnosticui-core** (lib) is still published manually — see the steps below.
 
-```bash
-npm whoami  # Should show: rlevin
-```
+**agnosticui-cli is now published automatically** via GitHub Actions when you push a `v2.*` tag. See [step 7](#7-tag-git-release-triggers-cli-publish) — the tag push replaces the manual CLI publish step.
 
-**Publish Core Library:**
+**Publish Core Library (manual):**
 
-**Make sure you've first bump the VERSION (v2/lib/package.json and v2/site/package.json which refers to it), and then rebuild with `npm run build` and have that latest build in corresponding `dist/`**
+**Make sure you've first bumped the VERSION (v2/lib/package.json and v2/site/package.json which refers to it), and then rebuilt with `npm run build`.**
 
 ```bash
 cd v2/lib
@@ -412,9 +410,11 @@ npm dist-tag add agnosticui-core@VERSION latest
 npm dist-tag ls agnosticui-core
 ```
 
-**Publish CLI:**
+**Publish CLI — DEPRECATED (automated via GitHub Actions):**
 
-**Make sure you've first bump the VERSION and then rebuild with `npm run build` and have that latest build in corresponding `dist/`**
+> ⚠️ **Deprecated:** The steps below are preserved for reference only. CLI publishing is now
+> automated — pushing a `v2.*` git tag triggers the `publish-cli.yml` workflow which builds,
+> tests, and publishes automatically. See [step 7](#7-tag-git-release-triggers-cli-publish).
 
 ```bash
 cd v2/cli
@@ -432,7 +432,22 @@ npm dist-tag add agnosticui-cli@VERSION latest
 npm dist-tag ls agnosticui-cli
 ```
 
-### 7. Verify Publications
+### 7. Tag Git Release — triggers CLI publish
+
+Pushing a `v2.*` tag triggers the `publish-cli.yml` GitHub Actions workflow, which:
+1. Validates the tag version matches `v2/cli/package.json`
+2. Runs `npm ci`, `npm run build`, `npm test`
+3. Publishes with `--tag alpha` (pre-release) or `--tag latest` (stable)
+4. Points the `latest` dist-tag to the new version (for pre-release tags)
+
+```bash
+git tag -a v2.0.0-alpha.X -m "Release v2.0.0-alpha.X"
+git push origin v2.0.0-alpha.X
+```
+
+Watch the publish at: https://github.com/AgnosticUI/agnosticui/actions
+
+### 8. Verify Publications
 
 ```bash
 npm info agnosticui-core
@@ -443,16 +458,9 @@ open https://www.npmjs.com/package/agnosticui-core
 open https://www.npmjs.com/package/agnosticui-cli
 ```
 
-### 8. Test Published Packages
+### 9. Test Published Packages
 
 Follow the "Testing After NPM Publication" section above.
-
-### 9. Tag Git Release
-
-```bash
-git tag -a v2.0.0-alpha.X -m "Release v2.0.0-alpha.X"
-git push origin v2.0.0-alpha.X
-```
 
 ## Quick Reference
 
@@ -461,21 +469,20 @@ git push origin v2.0.0-alpha.X
 cd v2/lib && npm install && npm run build && npm pack
 cd v2/cli && npm install && npm run build && npm pack
 
-# Publish
+# Publish core library (manual)
 cd v2/lib && npm publish --tag alpha
 npm dist-tag add agnosticui-core@VERSION latest
-cd v2/cli && npm publish --tag alpha
-npm dist-tag add agnosticui-cli@VERSION latest
+
+# Publish CLI (automated — just push the tag)
+git tag -a v2.0.0-alpha.X -m "Release v2.0.0-alpha.X"
+git push origin v2.0.0-alpha.X
+# → GitHub Actions runs publish-cli.yml automatically
 
 # Test in fresh environment
 mkdir /tmp/test && cd /tmp/test && npm init -y
 npm install -g agnosticui-cli@alpha
 ag init --framework vue
 ag add button
-
-# Tag release
-git tag -a vVERSION -m "Release vVERSION"
-git push --tags
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
- Add .github/workflows/publish-cli.yml triggered on v2.* tag push
- Validates tag version matches v2/cli/package.json before proceeding
- Runs npm ci, build, and test as gates before publish
- Determines dist-tag automatically: alpha for pre-release, latest for stable
- Runs npm dist-tag add to point latest at the new alpha release
- Uses OIDC trusted publishing (id-token: write) — no NPM_TOKEN secret needed
- Update v2/docs/CLI.md: document new automated flow in steps 6-7
- Mark old manual CLI publish steps as deprecated (preserved for reference)
- Update Quick Reference section to reflect tag-triggered publish