### PR TITLE
Fix #336: formStateRestoreCallback, _parentDisabled fix, and CustomStateSet

### DIFF
--- a/v2/lib/src/components/Checkbox/core/_Checkbox.spec.ts
+++ b/v2/lib/src/components/Checkbox/core/_Checkbox.spec.ts
@@ -480,6 +480,55 @@ describe('Checkbox - Comprehensive Tests', () => {
     });
   });
 
+  describe('FACE lifecycle (issue #336)', () => {
+    describe('formStateRestoreCallback', () => {
+      it('restores checked=true from a non-null state', async () => {
+        const checkbox = await createCheckbox({ name: 'test', value: 'yes', labelText: 'Accept' });
+        expect(checkbox.checked).toBe(false);
+        checkbox.formStateRestoreCallback('yes', 'restore');
+        await checkbox.updateComplete;
+        expect(checkbox.checked).toBe(true);
+      });
+
+      it('restores checked=false from a null state', async () => {
+        const checkbox = await createCheckbox({ name: 'test', value: 'yes', checked: true, labelText: 'Accept' });
+        expect(checkbox.checked).toBe(true);
+        checkbox.formStateRestoreCallback(null, 'restore');
+        await checkbox.updateComplete;
+        expect(checkbox.checked).toBe(false);
+      });
+
+      it('clears indeterminate on restore', async () => {
+        const checkbox = await createCheckbox({ indeterminate: true, labelText: 'Test' });
+        checkbox.formStateRestoreCallback('yes', 'restore');
+        await checkbox.updateComplete;
+        expect(checkbox.indeterminate).toBe(false);
+      });
+    });
+
+    describe('formDisabledCallback — _parentDisabled separation', () => {
+      it('does not re-enable a user-disabled control when fieldset is re-enabled', async () => {
+        const checkbox = await createCheckbox({ disabled: true, labelText: 'Disabled' });
+        checkbox.formDisabledCallback(true);
+        await checkbox.updateComplete;
+        checkbox.formDisabledCallback(false);
+        await checkbox.updateComplete;
+        expect(checkbox.disabled).toBe(true); // user's disabled state preserved
+      });
+
+      it('re-enables a control that was enabled before fieldset disabled it', async () => {
+        const checkbox = await createCheckbox({ labelText: 'Test' });
+        expect(checkbox.disabled).toBe(false);
+        checkbox.formDisabledCallback(true);
+        await checkbox.updateComplete;
+        expect(checkbox.disabled).toBe(true);
+        checkbox.formDisabledCallback(false);
+        await checkbox.updateComplete;
+        expect(checkbox.disabled).toBe(false);
+      });
+    });
+  });
+
   describe('Toggle Behavior', () => {
     it('should toggle checked state on click', async () => {
       const checkbox = await createCheckbox({

--- a/v2/lib/src/components/Checkbox/core/_Checkbox.ts
+++ b/v2/lib/src/components/Checkbox/core/_Checkbox.ts
@@ -365,6 +365,22 @@ export class AgCheckbox extends FaceMixin(LitElement) implements CheckboxProps {
   }
 
   /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores checked state from the previously saved form value.
+   * A non-null state means the checkbox was checked; null means unchecked.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.checked = state !== null;
+    this.indeterminate = false;
+    this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
    * Sync validity to ElementInternals by delegating to the inner
    * <input type="checkbox">. Required validation is handled natively
    * by the inner input; we just mirror its state.

--- a/v2/lib/src/components/Combobox/core/_Combobox.ts
+++ b/v2/lib/src/components/Combobox/core/_Combobox.ts
@@ -759,6 +759,14 @@ export class AgCombobox extends FaceMixin(LitElement) implements ComboboxProps {
       this._syncFormValue();
       this._syncValidity();
     }
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('readonly') ||
+      changedProperties.has('required') ||
+      changedProperties.has('value')
+    ) {
+      this._syncStates();
+    }
   }
 
   // Public methods
@@ -994,6 +1002,7 @@ export class AgCombobox extends FaceMixin(LitElement) implements ComboboxProps {
   override firstUpdated() {
     this._syncFormValue();
     this._syncValidity();
+    this._syncStates();
   }
 
   /**
@@ -1005,6 +1014,50 @@ export class AgCombobox extends FaceMixin(LitElement) implements ComboboxProps {
     this._selectionChanged();
     this._internals.setFormValue(null);
     this._internals.setValidity({});
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores the selected option(s) by matching saved values against this.options.
+   * Single: state is a string. Multiple: state is FormData.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    if (state === null) {
+      this._selectedOptions = [];
+    } else if (state instanceof FormData) {
+      const values = new Set(Array.from(state.getAll(this.name)) as string[]);
+      this._selectedOptions = this.options.filter(opt => values.has(opt.value));
+    } else if (typeof state === 'string') {
+      const found = this.options.find(opt => opt.value === state);
+      this._selectedOptions = found ? [found] : [];
+    }
+    this._selectionChanged();
+    this._syncFormValue();
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled) — combobox is disabled
+   *  :state(readonly) — combobox is read-only
+   *  :state(required) — combobox is required
+   *  :state(invalid)  — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('readonly', this.readonly);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   // ─── End FACE ─────────────────────────────────────────────────────────────

--- a/v2/lib/src/components/Input/core/_Input.spec.ts
+++ b/v2/lib/src/components/Input/core/_Input.spec.ts
@@ -1210,6 +1210,108 @@ describe('AgnosticUI v2 Event Conventions', () => {
   });
 });
 
+describe('AgInput - FACE lifecycle (issue #336)', () => {
+  describe('formStateRestoreCallback', () => {
+    it('restores value from a string state', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      el.name = 'username';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      expect(el.value).toBe('');
+      el.formStateRestoreCallback('Jane', 'restore');
+      await el.updateComplete;
+      expect(el.value).toBe('Jane');
+      document.body.removeChild(el);
+    });
+
+    it('restores empty string from a null state', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      el.name = 'username';
+      el.value = 'Bob';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      el.formStateRestoreCallback(null, 'restore');
+      await el.updateComplete;
+      expect(el.value).toBe('');
+      document.body.removeChild(el);
+    });
+
+    it('restores value from autocomplete mode', async () => {
+      const el = new AgInput();
+      el.label = 'Email';
+      el.name = 'email';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      el.formStateRestoreCallback('user@example.com', 'autocomplete');
+      await el.updateComplete;
+      expect(el.value).toBe('user@example.com');
+      document.body.removeChild(el);
+    });
+  });
+
+  describe('formDisabledCallback — _parentDisabled separation', () => {
+    it('does not re-enable a user-disabled input when fieldset is re-enabled', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      el.disabled = true;
+      document.body.appendChild(el);
+      await el.updateComplete;
+      el.formDisabledCallback(true);
+      await el.updateComplete;
+      el.formDisabledCallback(false);
+      await el.updateComplete;
+      expect(el.disabled).toBe(true); // user's disabled state preserved
+      document.body.removeChild(el);
+    });
+
+    it('re-enables an input that was enabled before fieldset disabled it', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      expect(el.disabled).toBe(false);
+      el.formDisabledCallback(true);
+      await el.updateComplete;
+      expect(el.disabled).toBe(true);
+      el.formDisabledCallback(false);
+      await el.updateComplete;
+      expect(el.disabled).toBe(false);
+      document.body.removeChild(el);
+    });
+  });
+
+  describe('_syncStates smoke test', () => {
+    // CustomStateSet (:state()) is not available in JSDOM, so we verify
+    // that toggling the relevant properties does not throw and the component
+    // remains in a valid, renderable state.
+    it('does not throw when disabled changes', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      expect(() => { el.disabled = true; }).not.toThrow();
+      await el.updateComplete;
+      expect(() => { el.disabled = false; }).not.toThrow();
+      await el.updateComplete;
+      document.body.removeChild(el);
+    });
+
+    it('does not throw when required changes', async () => {
+      const el = new AgInput();
+      el.label = 'Name';
+      document.body.appendChild(el);
+      await el.updateComplete;
+      expect(() => { el.required = true; }).not.toThrow();
+      await el.updateComplete;
+      expect(() => { el.required = false; }).not.toThrow();
+      await el.updateComplete;
+      document.body.removeChild(el);
+    });
+  });
+});
+
 // Helper functions for creating addon content in tests
 const createSearchIcon = () => {
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');

--- a/v2/lib/src/components/Input/core/_Input.ts
+++ b/v2/lib/src/components/Input/core/_Input.ts
@@ -496,6 +496,40 @@ export class AgInput extends FaceMixin(LitElement) implements InputProps {
     this.value = '';
     this._internals.setFormValue('');
     this._internals.setValidity({});
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores the input value from the previously saved form state.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.value = typeof state === 'string' ? state : '';
+    this._internals.setFormValue(this.value);
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled)  — input is disabled
+   *  :state(readonly)  — input is read-only
+   *  :state(required)  — input is required
+   *  :state(invalid)   — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('readonly', this.readonly);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   /**
@@ -678,10 +712,23 @@ export class AgInput extends FaceMixin(LitElement) implements InputProps {
     `;
   }
 
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('readonly') ||
+      changedProperties.has('required') ||
+      changedProperties.has('invalid')
+    ) {
+      this._syncStates();
+    }
+  }
+
   override firstUpdated() {
     // FACE: set initial form value and sync validity after first render
     this._internals.setFormValue(this.value ?? '');
     this._syncValidity();
+    this._syncStates();
 
     // Initial check for slot content
     setTimeout(() => {

--- a/v2/lib/src/components/Radio/core/_Radio.ts
+++ b/v2/lib/src/components/Radio/core/_Radio.ts
@@ -406,6 +406,20 @@ export class AgRadio extends FaceMixin(LitElement) implements RadioProps {
   }
 
   /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores checked state: checked when the saved state matches this radio's value.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.checked = state === this.value;
+    this._syncFormValue();
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
    * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
    *
    * Must be called AFTER _syncValidity() so that :state(invalid) reads the

--- a/v2/lib/src/components/Rating/core/_Rating.ts
+++ b/v2/lib/src/components/Rating/core/_Rating.ts
@@ -184,6 +184,7 @@ export class AgRating extends FaceMixin(LitElement) {
   override firstUpdated() {
     this._syncFormValue();
     this._syncValidity();
+    this._syncStates();
   }
 
   override updated(changedProperties: Map<string, unknown>) {
@@ -191,6 +192,14 @@ export class AgRating extends FaceMixin(LitElement) {
     if (changedProperties.has('value')) {
       this._syncFormValue();
       this._syncValidity();
+    }
+    if (
+      changedProperties.has('value') ||
+      changedProperties.has('readonly') ||
+      changedProperties.has('required') ||
+      changedProperties.has('invalid')
+    ) {
+      this._syncStates();
     }
   }
 
@@ -202,6 +211,39 @@ export class AgRating extends FaceMixin(LitElement) {
     this.value = 0;
     this._internals.setFormValue(null);
     this._internals.setValidity({});
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores the rating value from the previously saved form state.
+   * The state is a numeric string (e.g. "3" or "3.5"), or null for no rating.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.value = typeof state === 'string' ? parseFloat(state) : 0;
+    this._syncFormValue();
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(readonly) — rating is read-only
+   *  :state(required) — rating is required
+   *  :state(invalid)  — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('readonly', this.readonly);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   // ─── End FACE ─────────────────────────────────────────────────────────────

--- a/v2/lib/src/components/Select/core/_Select.ts
+++ b/v2/lib/src/components/Select/core/_Select.ts
@@ -114,6 +114,51 @@ export class Select extends FaceMixin(LitElement) implements SelectProps {
     }
     this._syncFormValue();
     this._internals.setValidity({});
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores the selected option(s) from the previously saved form state.
+   * Uses updateComplete to ensure options are in the DOM before restoring.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.updateComplete.then(() => {
+      if (!this.selectElement) return;
+      if (this.multiple && state instanceof FormData) {
+        const restored = new Set(Array.from(state.values()) as string[]);
+        Array.from(this.selectElement.options).forEach(opt => {
+          opt.selected = restored.has(opt.value);
+        });
+      } else if (typeof state === 'string') {
+        Array.from(this.selectElement.options).forEach(opt => {
+          opt.selected = opt.value === state;
+        });
+      }
+      this._syncFormValue();
+      this._syncValidity();
+      this._syncStates();
+    });
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled) — select is disabled
+   *  :state(required) — select is required
+   *  :state(invalid)  — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   /**
@@ -144,6 +189,17 @@ export class Select extends FaceMixin(LitElement) implements SelectProps {
 
   // ─── End FACE ─────────────────────────────────────────────────────────────
 
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('required') ||
+      changedProperties.has('invalid')
+    ) {
+      this._syncStates();
+    }
+  }
+
   protected firstUpdated() {
     // Ensure options are moved after first render
     this.handleSlotChange();
@@ -157,6 +213,7 @@ export class Select extends FaceMixin(LitElement) implements SelectProps {
     // FACE: set initial form value and sync validity after options are in place
     this._syncFormValue();
     this._syncValidity();
+    this._syncStates();
   }
 
   private handleSlotChange() {

--- a/v2/lib/src/components/SelectionButtonGroup/core/_SelectionButtonGroup.ts
+++ b/v2/lib/src/components/SelectionButtonGroup/core/_SelectionButtonGroup.ts
@@ -215,6 +215,46 @@ export class AgSelectionButtonGroup extends FaceMixin(LitElement) implements Sel
     this._internals.setFormValue(null);
     this._syncValidity();
     this._syncChildButtons();
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores selected value(s) from the previously saved form state.
+   * Radio mode: state is a single string. Checkbox mode: state is FormData.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    if (state === null) {
+      this._internalSelectedValues = [];
+    } else if (state instanceof FormData) {
+      this._internalSelectedValues = Array.from(state.getAll(this.name)) as string[];
+    } else if (typeof state === 'string') {
+      this._internalSelectedValues = [state];
+    }
+    this._syncFormValue();
+    this._syncValidity();
+    this._syncChildButtons();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled) — group is disabled
+   *  :state(required) — group is required
+   *  :state(invalid)  — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   // ─── End FACE ─────────────────────────────────────────────────────────────
@@ -260,12 +300,20 @@ export class AgSelectionButtonGroup extends FaceMixin(LitElement) implements Sel
     } else if (changedProperties.has('required')) {
       this._syncValidity();
     }
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('required') ||
+      changedProperties.has('_internalSelectedValues')
+    ) {
+      this._syncStates();
+    }
   }
 
   override firstUpdated() {
     this._syncChildButtons();
     this._syncFormValue();
     this._syncValidity();
+    this._syncStates();
   }
 
   private _getButtons(): AgSelectionButton[] {

--- a/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
+++ b/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
@@ -192,6 +192,46 @@ export class AgSelectionCardGroup extends FaceMixin(LitElement) implements Selec
     this._internals.setFormValue(null);
     this._syncValidity();
     this._syncChildCards();
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores selected value(s) from the previously saved form state.
+   * Radio mode: state is a single string. Checkbox mode: state is FormData.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    if (state === null) {
+      this._internalSelectedValues = [];
+    } else if (state instanceof FormData) {
+      this._internalSelectedValues = Array.from(state.getAll(this.name)) as string[];
+    } else if (typeof state === 'string') {
+      this._internalSelectedValues = [state];
+    }
+    this._syncFormValue();
+    this._syncValidity();
+    this._syncChildCards();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _syncValidity() so that :state(invalid) reads the
+   * freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled) — group is disabled
+   *  :state(required) — group is required
+   *  :state(invalid)  — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   // ─── End FACE ─────────────────────────────────────────────────────────────
@@ -235,12 +275,20 @@ export class AgSelectionCardGroup extends FaceMixin(LitElement) implements Selec
     } else if (changedProperties.has('required')) {
       this._syncValidity();
     }
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('required') ||
+      changedProperties.has('_internalSelectedValues')
+    ) {
+      this._syncStates();
+    }
   }
 
   override firstUpdated() {
     this._syncChildCards();
     this._syncFormValue();
     this._syncValidity();
+    this._syncStates();
   }
 
   private _getCards(): AgSelectionCard[] {

--- a/v2/lib/src/components/Slider/core/_Slider.ts
+++ b/v2/lib/src/components/Slider/core/_Slider.ts
@@ -671,12 +671,25 @@ export class AgSlider extends FaceMixin(LitElement) implements SliderProps {
 
   // ─── FACE ─────────────────────────────────────────────────────────────────
 
+  override updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has('disabled') ||
+      changedProperties.has('readonly') ||
+      changedProperties.has('required') ||
+      changedProperties.has('invalid')
+    ) {
+      this._syncStates();
+    }
+  }
+
   override firstUpdated() {
     // Capture default value for formResetCallback, then set initial form value
     this._defaultValue = Array.isArray(this.value)
       ? ([...this.value] as [number, number])
       : this.value;
     this._updateFormValue();
+    this._syncStates();
   }
 
   /**
@@ -688,6 +701,46 @@ export class AgSlider extends FaceMixin(LitElement) implements SliderProps {
       ? ([...this._defaultValue] as [number, number])
       : this._defaultValue;
     this._updateFormValue();
+    this._syncStates();
+  }
+
+  /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores the slider value from the previously saved FormData.
+   * Single mode: one entry (name, valueStr). Dual mode: two entries.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    if (!(state instanceof FormData) || !this.name) return;
+    const entries = Array.from(state.getAll(this.name)) as string[];
+    if (this.dual && entries.length === 2) {
+      this.value = [parseFloat(entries[0]), parseFloat(entries[1])];
+    } else if (entries.length === 1) {
+      this.value = parseFloat(entries[0]);
+    }
+    this._updateFormValue();
+    this._syncStates();
+  }
+
+  /**
+   * Sync CustomStateSet states so :state() pseudo-classes work from external CSS.
+   *
+   * Must be called AFTER _updateFormValue() (which also calls setValidity) so
+   * that :state(invalid) reads the freshly-updated _internals.validity.valid value.
+   *
+   * Exposed states:
+   *  :state(disabled)  — slider is disabled
+   *  :state(readonly)  — slider is read-only
+   *  :state(required)  — slider is required
+   *  :state(invalid)   — FACE constraint validation is failing
+   */
+  private _syncStates(): void {
+    this._setState('disabled', this.disabled);
+    this._setState('readonly', this.readonly);
+    this._setState('required', this.required);
+    this._setState('invalid', !this._internals.validity.valid);
   }
 
   // ─── End FACE ─────────────────────────────────────────────────────────────

--- a/v2/lib/src/components/Toggle/core/_Toggle.spec.ts
+++ b/v2/lib/src/components/Toggle/core/_Toggle.spec.ts
@@ -964,4 +964,74 @@ describe('AgToggle', () => {
       document.body.removeChild(el);
     });
   });
+
+  describe('FACE lifecycle (issue #336)', () => {
+    describe('formStateRestoreCallback', () => {
+      it('restores checked=true from a non-null state', async () => {
+        const el = document.createElement('ag-toggle') as AgToggle;
+        el.label = 'Test';
+        document.body.appendChild(el);
+        await el.updateComplete;
+        expect(el.checked).toBe(false);
+        el.formStateRestoreCallback('on', 'restore');
+        await el.updateComplete;
+        expect(el.checked).toBe(true);
+        document.body.removeChild(el);
+      });
+
+      it('restores checked=false from a null state', async () => {
+        const el = document.createElement('ag-toggle') as AgToggle;
+        el.label = 'Test';
+        el.checked = true;
+        document.body.appendChild(el);
+        await el.updateComplete;
+        el.formStateRestoreCallback(null, 'restore');
+        await el.updateComplete;
+        expect(el.checked).toBe(false);
+        document.body.removeChild(el);
+      });
+
+      it('restores checked from autocomplete mode', async () => {
+        const el = document.createElement('ag-toggle') as AgToggle;
+        el.label = 'Test';
+        document.body.appendChild(el);
+        await el.updateComplete;
+        el.formStateRestoreCallback('on', 'autocomplete');
+        await el.updateComplete;
+        expect(el.checked).toBe(true);
+        document.body.removeChild(el);
+      });
+    });
+
+    describe('formDisabledCallback — _parentDisabled separation', () => {
+      it('does not re-enable a user-disabled control when fieldset is re-enabled', async () => {
+        const el = document.createElement('ag-toggle') as AgToggle;
+        el.label = 'Test';
+        el.disabled = true; // user explicitly disabled
+        document.body.appendChild(el);
+        await el.updateComplete;
+        el.formDisabledCallback(true);
+        await el.updateComplete;
+        el.formDisabledCallback(false);
+        await el.updateComplete;
+        expect(el.disabled).toBe(true); // user's disabled state preserved
+        document.body.removeChild(el);
+      });
+
+      it('re-enables a control that was enabled before fieldset disabled it', async () => {
+        const el = document.createElement('ag-toggle') as AgToggle;
+        el.label = 'Test';
+        document.body.appendChild(el);
+        await el.updateComplete;
+        expect(el.disabled).toBe(false);
+        el.formDisabledCallback(true);
+        await el.updateComplete;
+        expect(el.disabled).toBe(true);
+        el.formDisabledCallback(false);
+        await el.updateComplete;
+        expect(el.disabled).toBe(false); // restored to original enabled state
+        document.body.removeChild(el);
+      });
+    });
+  });
 });

--- a/v2/lib/src/components/Toggle/core/_Toggle.ts
+++ b/v2/lib/src/components/Toggle/core/_Toggle.ts
@@ -397,6 +397,21 @@ export class AgToggle extends FaceMixin(LitElement) implements ToggleProps {
   }
 
   /**
+   * FACE lifecycle: called on session restore or browser autofill.
+   * Restores checked state from the previously saved form value.
+   * A non-null state means the toggle was on; null means it was off.
+   */
+  override formStateRestoreCallback(
+    state: File | string | FormData | null,
+    _mode: 'restore' | 'autocomplete'
+  ): void {
+    this.checked = state !== null;
+    this._internals.setFormValue(this.checked ? (this.value || 'on') : null);
+    this._syncValidity();
+    this._syncStates();
+  }
+
+  /**
    * Sync validity state to ElementInternals.
    * Toggle has no inner <input> to delegate to, so required validation
    * is implemented directly: unchecked + required = valueMissing.

--- a/v2/lib/src/shared/face-mixin.ts
+++ b/v2/lib/src/shared/face-mixin.ts
@@ -107,6 +107,11 @@ export declare class FaceMixinInterface {
   /** FACE lifecycle — called on form reset; subclasses should override */
   formResetCallback(): void;
   /**
+   * FACE lifecycle — called when the browser restores session state or autofills.
+   * Subclasses should override to restore their own state from the saved value.
+   */
+  formStateRestoreCallback(state: File | string | FormData | null, mode: 'restore' | 'autocomplete'): void;
+  /**
    * Toggle a custom state in ElementInternals.states (CustomStateSet).
    * Enables :state() pseudo-class targeting from external CSS.
    * Guards against environments where states is unavailable.
@@ -134,6 +139,16 @@ export const FaceMixin = <T extends Constructor<LitElement>>(superClass: T) => {
      * Must be initialized in constructor before any other use.
      */
     protected _internals!: ElementInternals;
+
+    /**
+     * The disabled state the user set on this element itself (via attribute or property),
+     * captured before a <fieldset disabled> ancestor overwrites it.
+     * Restored when the fieldset is re-enabled so the two sources don't stomp each other.
+     */
+    private _ownDisabled = false;
+
+    /** True while a <fieldset disabled> ancestor is disabling this element. */
+    private _parentDisabled = false;
 
     /**
      * The name under which this control's value is submitted with the parent form.
@@ -182,14 +197,21 @@ export const FaceMixin = <T extends Constructor<LitElement>>(superClass: T) => {
 
     /**
      * FACE lifecycle: called when a <fieldset disabled> ancestor is toggled.
-     * Syncs the component's own `disabled` property so it renders correctly.
-     *
-     * Note: this only fires for inherited disabled state (via fieldset), not
-     * for the element's own `disabled` attribute — both paths must be handled.
+     * Separates parent-disabled state from the element's own `disabled` attribute
+     * so re-enabling a fieldset does not accidentally re-enable an intentionally
+     * disabled control.
      */
     formDisabledCallback(disabled: boolean): void {
-      // `disabled` is declared on each subclass via @property; cast to access it
-      (this as unknown as { disabled: boolean }).disabled = disabled;
+      if (disabled) {
+        // Save the user's own disabled state before the fieldset takes over.
+        this._ownDisabled = (this as unknown as { disabled: boolean }).disabled;
+        this._parentDisabled = true;
+        (this as unknown as { disabled: boolean }).disabled = true;
+      } else {
+        this._parentDisabled = false;
+        // Restore only the user-set state — do not blindly set false.
+        (this as unknown as { disabled: boolean }).disabled = this._ownDisabled;
+      }
     }
 
     /**
@@ -198,6 +220,26 @@ export const FaceMixin = <T extends Constructor<LitElement>>(superClass: T) => {
      * and call this._internals.setFormValue('') / setValidity({}).
      */
     formResetCallback(): void {
+      // no-op default — override in subclass
+    }
+
+    /**
+     * FACE lifecycle: called when the browser restores form state from session history
+     * (back/forward navigation) or when the browser autofills the field.
+     *
+     * `state` is the value that was previously passed to setFormValue():
+     *   - a string for single-value controls
+     *   - a FormData for multi-value controls (multi-select, checkbox groups)
+     *   - null if the control had no value
+     *
+     * `mode` is 'restore' for session-history restores and 'autocomplete' for autofill.
+     *
+     * Default is a no-op. Subclasses should override to restore their own state.
+     */
+    formStateRestoreCallback(
+      _state: File | string | FormData | null,
+      _mode: 'restore' | 'autocomplete'
+    ): void {
       // no-op default — override in subclass
     }
 


### PR DESCRIPTION
```md
Fix #336: formStateRestoreCallback, _parentDisabled fix, and CustomStateSet

  Summary of changes across 14 files:

  ┌────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │              Area              │                                                           What changed                                                            │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ face-mixin.ts                  │ Fixed formDisabledCallback with _ownDisabled/_parentDisabled to prevent re-enabling user-disabled controls; added                 │
  │                                │ formStateRestoreCallback no-op with full JSDoc; updated FaceMixinInterface                                                        │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Toggle, Checkbox, Radio        │ Added formStateRestoreCallback (Toggle/Checkbox restore checked from null/non-null; Radio checks state === this.value)            │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Input                          │ Added formStateRestoreCallback, _syncStates(), updated() hook                                                                     │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Select                         │ Added formStateRestoreCallback (async via updateComplete; handles both single and FormData multi-select), _syncStates(),          │
  │                                │ updated()                                                                                                                         │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Slider                         │ Added formStateRestoreCallback (extracts single/dual values from FormData), _syncStates(), updated()                              │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Rating                         │ Added formStateRestoreCallback (parses float from string), _syncStates(), updated updated() and firstUpdated()                    │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ SelectionButtonGroup/CardGroup │ Added formStateRestoreCallback (restores _internalSelectedValues from string or FormData), _syncStates(), updated hooks           │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Combobox                       │ Added formStateRestoreCallback (matches saved values against this.options), _syncStates(), updated hooks                          │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ Toggle + Checkbox + Input      │ 17 new tests covering formStateRestoreCallback, _parentDisabled fix, and _syncStates smoke tests                                  │
  │ specs                          │                                                                                                                                   │
  └────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

  ```