### PR TITLE
Fix #349: prevent layout shift on dialog/drawer open

### DIFF
--- a/v2/lib/src/components/Dialog/core/_dialog.ts
+++ b/v2/lib/src/components/Dialog/core/_dialog.ts
@@ -164,10 +164,15 @@ export class AgnosticDialog extends LitElement implements DialogProps {
     const currentCount = parseInt(document.body.getAttribute('data-dialog-count') || '0', 10);
 
     if (currentCount === 0) {
-      // First dialog - store original overflow and lock scroll
+      // First dialog - store original overflow and scrollbar-gutter, then lock scroll.
+      // scrollbar-gutter: stable reserves the gutter space so the page does not
+      // shift when the scrollbar disappears due to overflow: hidden.
       document.body.setAttribute('data-dialog-original-overflow',
         document.body.style.overflow || '');
+      document.body.setAttribute('data-dialog-original-scrollbar-gutter',
+        document.body.style.scrollbarGutter || '');
       document.body.style.overflow = 'hidden';
+      document.body.style.scrollbarGutter = 'stable';
       document.body.setAttribute('data-dialog-scroll-locked', '');
     }
 
@@ -181,10 +186,13 @@ export class AgnosticDialog extends LitElement implements DialogProps {
     document.body.setAttribute('data-dialog-count', newCount.toString());
 
     if (newCount === 0) {
-      // Last dialog closing - restore original overflow
+      // Last dialog closing - restore original overflow and scrollbar-gutter
       const originalOverflow = document.body.getAttribute('data-dialog-original-overflow');
+      const originalScrollbarGutter = document.body.getAttribute('data-dialog-original-scrollbar-gutter');
       document.body.style.overflow = originalOverflow || '';
+      document.body.style.scrollbarGutter = originalScrollbarGutter || '';
       document.body.removeAttribute('data-dialog-original-overflow');
+      document.body.removeAttribute('data-dialog-original-scrollbar-gutter');
       document.body.removeAttribute('data-dialog-scroll-locked');
       document.body.removeAttribute('data-dialog-count');
     }


### PR DESCRIPTION
## Summary

- Sets `scrollbar-gutter: stable` on `<body>` alongside `overflow: hidden` when a Dialog or Drawer opens
- Saves and restores `scrollbarGutter` using the existing `data-attribute` pattern, matching how `overflow` is already handled
- Drawer gets the fix for free — it delegates entirely to Dialog

## What was happening

When `ag-dialog` (or `ag-drawer`) opened, `overflow: hidden` removed the scrollbar, causing page content to shift ~17px into the reclaimed gutter space.

## Why this fixes it

`scrollbar-gutter: stable` reserves gutter space even when the scrollbar is hidden. The layout is unchanged whether the scrollbar is visible or not.

## Files changed

- `v2/lib/src/components/Dialog/core/_dialog.ts` — only change needed

## A11y impact

None. Focus trap, `aria-modal`, keyboard handling, and focus restoration are all unaffected.

Closes #349