### PR TITLE
Fix #356: update home page button to link to /playbooks/

### DIFF
--- a/v2/site/docs/index.md
+++ b/v2/site/docs/index.md
@@ -77,9 +77,9 @@ onUnmounted(() => {
     shape="capsule"
     size="xl"
     class="jumbo-button"
-    @click="() => router.go('/playbooks/login')"
+    @click="() => router.go('/playbooks/')"
   >
-    View Login Playbook →
+    View Playbooks →
   </VueButtonFx>
 </div>
 


### PR DESCRIPTION
## Summary
- Updates the home page "View Login Playbook" button to link to `/playbooks/` instead of `/playbooks/login/`
- Changes button text to "View Playbooks →"

Closes #356