### PR TITLE
Fix #357: allow playbook screenshots to fill available width on tablet+

### DIFF
--- a/v2/site/docs/.vitepress/theme/custom.css
+++ b/v2/site/docs/.vitepress/theme/custom.css
@@ -653,10 +653,6 @@ make it a bit more aesthetically pleasing. */
   .playbook-screenshot-item {
     flex: 1 1 auto;
   }
-
-  .playbook-screenshot {
-    width: 100%;
-  }
 }
 
 /* Large screens: bigger max-height */


### PR DESCRIPTION
## Summary
- Changes `flex: 0 1 auto` to `flex: 1 1 auto` on `.playbook-screenshot-item` at 768px+ so screenshot items can grow to fill available width
- Replaces `max-height: 450px` with `width: 100%` on `.playbook-screenshot` so images aren't constrained to a narrow height on MacBook/desktop viewports

Closes #357