### PR TITLE
Fix #369: codegen infrastructure — ts-morph setup + codegen.config.ts

### DIFF
--- a/v2/schema/package-lock.json
+++ b/v2/schema/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "ts-morph": "^24.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.2",
         "vitest": "^3.2.4"
@@ -847,6 +848,18 @@
         "win32"
       ]
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.25.0.tgz",
+      "integrity": "sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^9.0.4",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.9"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -997,6 +1010,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1033,6 +1063,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1215,6 +1252,22 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1240,6 +1293,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1473,6 +1533,17 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ts-morph": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-24.0.0.tgz",
+      "integrity": "sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.25.0",
+        "code-block-writer": "^13.0.3"
+      }
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/v2/schema/package.json
+++ b/v2/schema/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "test": "vitest run",
     "build": "tsc",
+    "codegen": "tsx scripts/codegen.ts",
+    "check-codegen": "tsx scripts/check-codegen.ts",
     "m4": "npx tsx m4-llm-test.ts",
     "m4:dry": "npx tsx m4-llm-test.ts --dry-run"
   },
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "ts-morph": "^24.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/v2/schema/scripts/codegen.config.ts
+++ b/v2/schema/scripts/codegen.config.ts
@@ -1,0 +1,65 @@
+// v2/schema/scripts/codegen.config.ts
+// Update this file when runtime-state props change in core interfaces.
+// Function-typed props (onClick, onChange, etc.) are auto-detected by the
+// codegen via ts-morph — do NOT list them here.
+
+/**
+ * omitConfig: non-function props to exclude per component.
+ * Only needed for props that are runtime-stateful or render-internal
+ * and cannot be auto-detected by type inspection.
+ *
+ * Do NOT list function-typed props here — they are handled automatically.
+ * Keys use the Ag-prefixed SDUI name (e.g. AgButton, not Button).
+ */
+export const omitConfig: Record<string, string[]> = {
+  // toggle: mode requiring JS to track press state; pressed: current toggle state
+  AgButton:      ['toggle', 'pressed'],
+  AgButtonFx:    ['toggle', 'pressed'],
+
+  // indeterminate: tri-state requiring JS to set; theme: internal CSS theming hook
+  AgCheckbox:    ['indeterminate', 'theme'],
+
+  // pressed: current toggle state
+  AgIconButton:  ['pressed'],
+  AgIconButtonFx: ['pressed'],
+
+  // validationMessages: complex nested object; errorMessage covers SDUI needs
+  AgToggle:      ['validationMessages'],
+};
+
+/**
+ * actionAliasMap: maps function prop names to their SDUI string alias replacements.
+ * When the codegen finds a function-typed prop whose name appears here, it
+ * emits an optional string prop with the alias name instead of dropping it entirely.
+ * Function props NOT in this map are silently dropped (low-level browser events
+ * like onFocus, onBlur, onInput, onShow, onHide are not SDUI-actionable).
+ */
+export const actionAliasMap: Record<string, string> = {
+  onClick:              'on_click',
+  onChange:             'on_change',
+  onToggleChange:       'on_change',
+  onIconButtonClick:    'on_click',
+  onIconButtonActivate: 'on_activate',
+  onTagRemove:          'on_remove',
+  onAlertDismiss:       'on_dismiss',
+  onBreadcrumbClick:    'on_click',
+  onToggle:             'on_toggle',
+};
+
+/**
+ * skipComponents: component directory names to exclude from all generated output.
+ * These require controlled runtime state that cannot be expressed in a static node.
+ */
+export const skipComponents: string[] = [
+  'Collapsible',    // requires open/close state
+  'Combobox',       // complex filtering + multi-select state
+  'Dialog',         // lifecycle-driven open/close
+  'Drawer',         // lifecycle-driven open/close
+  'Menu',           // complex open + selected-value state
+  'Popover',        // show/hide trigger management
+  'ScrollToButton', // scroll-detection behavioral component
+  'Sidebar',        // open + collapsed state management
+  'SidebarNav',     // no Props interface; pure slot composition
+  'Toast',          // autoDismiss + open/close lifecycle
+  'VisuallyHidden', // no Props interface; pure slot wrapper
+];

--- a/v2/schema/scripts/codegen.ts
+++ b/v2/schema/scripts/codegen.ts
@@ -1,0 +1,113 @@
+// Stub for sub-issue #369 — validates codegen.config.ts against live source interfaces.
+// Full code generation implemented in sub-issue #370.
+
+import { Project, type Symbol as MorphSymbol } from 'ts-morph';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { omitConfig, actionAliasMap, skipComponents } from './codegen.config.js';
+
+// scripts/ -> schema/ -> v2/ -> agnosticui/
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const GLOB = `${ROOT}/v2/lib/src/components/*/core/_*.ts`;
+
+function isFunctionSymbol(sym: MorphSymbol): boolean {
+  const decl = sym.getValueDeclaration();
+  if (!decl) return false;
+  // getNonNullableType strips `| undefined` from optional props before checking
+  return decl.getType().getNonNullableType().getCallSignatures().length > 0;
+}
+
+async function main() {
+  const project = new Project({
+    tsConfigFilePath: resolve(ROOT, 'v2/lib/tsconfig.json'),
+    skipAddingFilesFromTsConfig: true,
+  });
+  project.addSourceFilesAtPaths(GLOB);
+
+  // Exclude spec files picked up by the glob
+  const sourceFiles = project.getSourceFiles().filter(
+    sf => !sf.getFilePath().endsWith('.spec.ts')
+  );
+
+  let errors = 0;
+
+  // --- Validate omitConfig entries ---
+  for (const sf of sourceFiles) {
+    const parts = sf.getFilePath().split('/');
+    const coreIdx = parts.lastIndexOf('core');
+    if (coreIdx < 1) continue;
+    const componentName = parts[coreIdx - 1];
+
+    if (skipComponents.includes(componentName)) continue;
+
+    const sdui = `Ag${componentName}`;
+    if (!(sdui in omitConfig)) continue;
+
+    const iface = sf.getInterface(`${componentName}Props`);
+    if (!iface) {
+      console.warn(
+        `WARN: no ${componentName}Props in ${sf.getFilePath()} — skipping stale check for ${sdui}`
+      );
+      continue;
+    }
+
+    // Use getType().getProperties() to include props inherited from base interfaces
+    const allProps = iface.getType().getProperties();
+    const propByName = new Map(allProps.map(sym => [sym.getName(), sym]));
+
+    for (const omittedProp of omitConfig[sdui]) {
+      if (!propByName.has(omittedProp)) {
+        console.error(
+          `ERROR: omitConfig lists '${omittedProp}' in ${sdui} ` +
+          `but ${componentName}Props no longer has that property. Remove it.`
+        );
+        errors++;
+        continue;
+      }
+
+      // Must not be function-typed — those are auto-detected, not manually listed
+      const sym = propByName.get(omittedProp)!;
+      if (isFunctionSymbol(sym)) {
+        console.error(
+          `ERROR: omitConfig lists '${omittedProp}' in ${sdui} ` +
+          `but that prop is function-typed and will be auto-detected. ` +
+          `Remove it from omitConfig (add to actionAliasMap if it needs a string alias).`
+        );
+        errors++;
+      }
+    }
+  }
+
+  // --- Validate actionAliasMap entries ---
+  // Collect all function-typed prop names across every discovered Props interface
+  const allFunctionPropNames = new Set<string>();
+  for (const sf of sourceFiles) {
+    const parts = sf.getFilePath().split('/');
+    const coreIdx = parts.lastIndexOf('core');
+    if (coreIdx < 1) continue;
+    const componentName = parts[coreIdx - 1];
+    if (skipComponents.includes(componentName)) continue;
+
+    const iface = sf.getInterface(`${componentName}Props`);
+    if (!iface) continue;
+
+    for (const sym of iface.getType().getProperties()) {
+      if (isFunctionSymbol(sym)) {
+        allFunctionPropNames.add(sym.getName());
+      }
+    }
+  }
+
+  for (const aliasKey of Object.keys(actionAliasMap)) {
+    if (!allFunctionPropNames.has(aliasKey)) {
+      console.warn(
+        `WARN: actionAliasMap lists '${aliasKey}' but no discovered Props interface has that function prop.`
+      );
+    }
+  }
+
+  if (errors > 0) process.exit(1);
+  console.log('codegen.config.ts is valid.');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
- Add ts-morph devDependency and codegen/check-codegen npm scripts to v2/schema/package.json
- Create v2/schema/scripts/codegen.config.ts with omitConfig (runtime-state props only), actionAliasMap (function prop to string alias mapping), and skipComponents (components too stateful for SDUI)
- Create v2/schema/scripts/codegen.ts stub that validates the config against live source interfaces using ts-morph: inherited prop lookup via getType().getProperties(), optional function detection via getNonNullableType(), and spec file filtering

All 28 existing schema tests pass. npm run codegen exits 0.