### PR TITLE
Fix tsc: emit aria-label instead of ariaLabel in React renderer

### DIFF
--- a/v2/renderers/react/src/AgDynamicRenderer.tsx
+++ b/v2/renderers/react/src/AgDynamicRenderer.tsx
@@ -125,7 +125,7 @@ function renderNode(
           size={node.size}
           shape={node.shape}
           variant={node.variant}
-          ariaLabel={node.ariaLabel} />
+          aria-label={node.ariaLabel} />
       );
 
     case 'AgBadge':
@@ -168,7 +168,7 @@ function renderNode(
           key={node.id}
           type={node.type}
           primary={node.primary}
-          ariaLabel={node.ariaLabel}
+          aria-label={node.ariaLabel}
           onBreadcrumbClick={() => dispatch(node.on_click, actions)} />
       );
 
@@ -187,7 +187,7 @@ function renderNode(
           type={node.type}
           disabled={node.disabled}
           loading={node.loading}
-          ariaLabel={node.ariaLabel}
+          aria-label={node.ariaLabel}
           onClick={() => dispatch(node.on_click, actions)}
           onToggle={() => dispatch(node.on_toggle, actions)}
         >
@@ -210,7 +210,7 @@ function renderNode(
           type={node.type}
           disabled={node.disabled}
           loading={node.loading}
-          ariaLabel={node.ariaLabel}
+          aria-label={node.ariaLabel}
           fx={node.fx}
           fxSpeed={node.fxSpeed}
           fxEase={node.fxEase}
@@ -382,7 +382,7 @@ function renderNode(
           labelHidden={node.labelHidden}
           labelPosition={node.labelPosition}
           noLabel={node.noLabel}
-          ariaLabel={node.ariaLabel}
+          aria-label={node.ariaLabel}
           name={node.name}
           type={node.type}
           value={node.value}
@@ -461,7 +461,7 @@ function renderNode(
           buttonBordered={node.buttonBordered}
           external={node.external}
           disabled={node.disabled}
-          ariaLabel={node.ariaLabel}
+          aria-label={node.ariaLabel}
           onClick={() => dispatch(node.on_click, actions)}
         >
           {renderChildren(node.children)}
@@ -473,7 +473,7 @@ function renderNode(
         <ReactLoader
           key={node.id}
           size={node.size}
-          ariaLabel={node.ariaLabel} />
+          aria-label={node.ariaLabel} />
       );
 
     case 'AgMark':
@@ -663,7 +663,7 @@ function renderNode(
         <ReactSpinner
           key={node.id}
           size={node.size}
-          ariaLabel={node.ariaLabel} />
+          aria-label={node.ariaLabel} />
       );
 
     case 'AgTabs':
@@ -673,7 +673,7 @@ function renderNode(
           activation={node.activation}
           activeTab={node.activeTab}
           orientation={node.orientation}
-          ariaLabel={node.ariaLabel} />
+          aria-label={node.ariaLabel} />
       );
 
     case 'AgTag':

--- a/v2/schema/scripts/codegen.config.ts
+++ b/v2/schema/scripts/codegen.config.ts
@@ -142,6 +142,19 @@ export const typeOverrides: Record<string, Record<string, { tsType: string; zodE
 };
 
 /**
+ * reactPropRenames: JSX attribute name overrides for the React renderer.
+ * Used when a Lit element property name conflicts with a standard HTML attribute
+ * that @lit/react exposes under a different name in its TypeScript types.
+ *
+ * Example: Lit stores 'ariaLabel' as a property but @lit/react expects the
+ * standard HTML 'aria-label' attribute. The SDUI schema keeps 'ariaLabel' so
+ * LLMs can set it; the React renderer emits 'aria-label' so tsc passes.
+ */
+export const reactPropRenames: Record<string, string> = {
+  ariaLabel: 'aria-label',
+};
+
+/**
  * vueDefaultImportComponents: component names whose agnosticui-core Vue export
  * resolves to the compiled component file directly (not an index.js re-export),
  * so they must be imported as a default rather than a named export.

--- a/v2/schema/scripts/codegen.ts
+++ b/v2/schema/scripts/codegen.ts
@@ -6,7 +6,7 @@ import { Project, type Type, type InterfaceDeclaration, type Symbol as MorphSymb
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { writeFileSync } from 'fs';
-import { omitConfig, actionAliasMap, typeOverrides, skipComponents, rendererSlotConfig, vueDefaultImportComponents, type RendererSlot } from './codegen.config.js';
+import { omitConfig, actionAliasMap, typeOverrides, skipComponents, rendererSlotConfig, vueDefaultImportComponents, reactPropRenames, type RendererSlot } from './codegen.config.js';
 
 // scripts/ -> schema/ -> v2/ -> agnosticui/
 export const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -299,7 +299,8 @@ function generateReactCase(c: ComponentData): string {
   propLines.push(`        <${wrapper}`);
   propLines.push(`          key={node.id}`);
   for (const p of directProps) {
-    propLines.push(`          ${p.name}={node.${quoteName(p.name)}}`);
+    const jsxAttr = reactPropRenames[p.name] ?? p.name;
+    propLines.push(`          ${jsxAttr}={node.${quoteName(p.name)}}`);
   }
   for (const a of c.actions) {
     propLines.push(`          ${a.sourceName}={() => dispatch(node.${quoteName(a.alias)}, actions)}`);


### PR DESCRIPTION
Part of #353 stretch goals.

## Problem
`tsc --noEmit` in `v2/renderers/react/` produced 9 `TS2322` errors across Avatar, Breadcrumb, Button, ButtonFx, Input, Link, Loader, Spinner, and Tabs. All had the same root cause: the codegen was emitting `ariaLabel={node.ariaLabel}` but `@lit/react` `createComponent` types expose the standard HTML `aria-label` attribute, not the camelCase Lit property name.

## Fix
- Add `reactPropRenames: Record<string, string>` to `codegen.config.ts` with `ariaLabel: 'aria-label'`
- Apply the rename in `generateReactCase`: JSX attribute uses the remapped name, node access uses the original schema key
- The SDUI schema keeps `ariaLabel` so LLMs can set accessibility labels in node trees

## Verification
- `tsc --noEmit` in `v2/renderers/react/` — zero errors (excluding known workspace `@agnosticui/schema` linking)
- `npm run check-codegen` — all 6 files up to date
- `npm test` — 28/28 passing