### PR TITLE
docs(sdui): SDUI architecture guide and LLM prompt guide (#393 #402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ Every tool sees the **raw source**. This creates a high-fidelity environment for
 
 This is the architecture for the next era of development: **context-aware, framework-agnostic, and AI-ready.**
 
-The schema-driven layer ships with a **coverage registry** — a single document that tracks which components have SDUI schema coverage, renderer parity across React/Vue/Lit, and why any props or components are deferred: [`v2/docs/schema-coverage.md`](./v2/docs/schema-coverage.md).
+The schema-driven layer ships with three companion documents:
+
+- [`v2/docs/sdui-architecture.md`](./v2/docs/sdui-architecture.md) — full system architecture: codegen pipeline, node graph model, renderers, CI gates, and key design decisions
+- [`v2/docs/llm-prompt-guide.md`](./v2/docs/llm-prompt-guide.md) — copy-paste system prompt template and few-shot examples for generating valid `AgNode[]` graphs
+- [`v2/docs/schema-coverage.md`](./v2/docs/schema-coverage.md) — per-component SDUI coverage registry, renderer parity status, and omission reasons
 
 ---
 

--- a/v2/docs/llm-prompt-guide.md
+++ b/v2/docs/llm-prompt-guide.md
@@ -1,0 +1,274 @@
+# LLM Prompt Guide: Generating AgNode Graphs
+
+This guide explains how to instruct a large language model to emit `AgNode[]` arrays for the AgnosticUI SDUI system instead of JSX, Vue templates, or raw HTML. For the full system picture (codegen, renderers, CI), see [sdui-architecture.md](./sdui-architecture.md).
+
+---
+
+## Why node graphs instead of JSX or HTML
+
+- **Framework-agnostic:** a single `AgNode[]` array renders identically in React, Vue, and Lit via the matching `AgDynamicRenderer`.
+- **Validatable at runtime:** `validateGraph()` checks every node against the Zod schema and verifies that all child ID references resolve within the graph, before any rendering occurs.
+- **LLM-readable contract:** the `component` field is a string literal that maps to an exact Zod schema variant. The LLM only needs to know valid component names and their props.
+- **Plain JSON:** nodes are ordinary objects with no functions, no imports, and no framework syntax. Any agent, pipeline, or storage layer can read, diff, or patch them.
+
+---
+
+## The system prompt template
+
+Copy and customize the block below. Replace the schema JSON placeholder with the actual content of `v2/schema/agnosticui-schema.json` when context budget allows (see [Using agnosticui-schema.json as LLM context](#using-agnosticui-schemajson-as-llm-context)).
+
+```
+You are generating UI node graphs for the AgnosticUI SDUI system.
+
+Output rules:
+- Respond ONLY with a JSON code block containing an AgNode[] array.
+- Do not include any prose, explanation, imports, or framework code.
+- Every node MUST have a unique "id" (kebab-case string) and a "component" field.
+
+Valid component names (use exactly as written):
+AgAccordion, AgAlert, AgAspectRatio, AgAvatar, AgBadge, AgBadgeFx,
+AgBreadcrumb, AgButton, AgButtonFx, AgCard, AgCheckbox, AgDialog,
+AgDivider, AgDrawer, AgFieldset, AgHeader, AgIcon, AgIconButton,
+AgIconButtonFx, AgInput, AgIntlFormatter, AgKbd, AgLink, AgLoader,
+AgMark, AgMessageBubble, AgPopover, AgProgress, AgRadio, AgRating,
+AgSelect, AgSelectionButton, AgSelectionButtonGroup, AgSelectionCard,
+AgSelectionCardGroup, AgSpinner, AgTabs, AgTag, AgToggle, AgTooltip,
+AgText
+
+Graph structure rules:
+- The graph is a FLAT array. Do not nest node objects inside other node objects.
+- "children" is an array of ID strings, not an array of node objects.
+  CORRECT:   { "id": "card-1", "component": "AgCard", "children": ["title-1", "btn-1"] }
+  INCORRECT: { "id": "card-1", "component": "AgCard", "children": [{ "id": "title-1", ... }] }
+- Every ID listed in a "children" array must appear as a top-level node in the array.
+
+AgText (renderer primitive):
+- Use AgText for headings, paragraphs, labels, and span text.
+- Props: "text" (required string), "el" (optional: "p" | "span" | "h1" | "h2" | "h3" | "h4" | "label")
+- AgButton and similar label-child components must wrap their visible text in an AgText child node.
+
+Action aliases (interactive callbacks):
+- Do not use function values. Use string aliases instead.
+- on_click     — button / link / icon-button click
+- on_change    — input / toggle / select change
+- on_dismiss   — dismissible alert dismiss
+- on_toggle    — collapsible-style toggle
+- on_open / on_close / on_cancel — dialog and drawer lifecycle
+- on_show / on_hide — popover show/hide
+- on_remove    — removable tag
+- on_activate  — icon button activate
+
+Prop validation:
+- Use only enum values documented in agnosticui-schema.json for props like "variant", "size", "type".
+- AgButton variant: "primary" | "secondary" | "success" | "warning" | "danger" | "monochrome"
+- AgInput type: "text" | "password" | "email" | "number" | "search" | "tel" | "url" | "date" | "datetime-local" | "month" | "time" | "week"
+- AgToggle size: "sm" | "md" | "lg"
+
+The source of truth for all valid props and enums is agnosticui-schema.json.
+```
+
+---
+
+## Few-shot example 1: valid login form graph
+
+A complete `AgNode[]` for a login form with email, password, a remember-me toggle, and a sign-in button.
+
+```json
+[
+  {
+    "id": "login-email",
+    "component": "AgInput",
+    "label": "Email",
+    "type": "email",
+    "placeholder": "you@example.com",
+    "required": true
+  },
+  {
+    "id": "login-password",
+    "component": "AgInput",
+    "label": "Password",
+    "type": "password",
+    "required": true
+  },
+  {
+    "id": "login-remember",
+    "component": "AgToggle",
+    "label": "Remember me"
+  },
+  {
+    "id": "login-submit",
+    "component": "AgButton",
+    "variant": "primary",
+    "type": "submit",
+    "on_click": "handle_login",
+    "children": ["login-submit-label"]
+  },
+  {
+    "id": "login-submit-label",
+    "component": "AgText",
+    "text": "Sign in"
+  }
+]
+```
+
+Passing this to `validateGraph()`:
+
+```ts
+import { validateGraph } from '@agnosticui/schema';
+
+const result = validateGraph(nodes);
+// result.success === true
+// result.errors  === []
+```
+
+---
+
+## Few-shot example 2: common mistakes Zod rejects
+
+### Mistake 1: invalid enum value on `variant`
+
+```json
+{
+  "id": "btn-1",
+  "component": "AgButton",
+  "variant": "rainbow"
+}
+```
+
+**Why it fails:** `variant` on `AgButton` is `z.enum(['primary', 'secondary', 'accent', 'success', 'warning', 'danger', 'monochrome'])`. The value `"rainbow"` is not a member.
+
+**Fix:** use `"primary"` or another valid variant string.
+
+### Mistake 2: nested objects in `children`
+
+```json
+{
+  "id": "card-1",
+  "component": "AgCard",
+  "children": [
+    { "id": "title-1", "component": "AgText", "text": "Hello" }
+  ]
+}
+```
+
+**Why it fails:** `children` is `z.array(z.string())`. An object is not a string.
+
+**Fix:** make `title-1` a sibling in the top-level array and reference it by ID string.
+
+```json
+[
+  { "id": "card-1", "component": "AgCard", "children": ["title-1"] },
+  { "id": "title-1", "component": "AgText", "text": "Hello" }
+]
+```
+
+### Mistake 3: missing `id` field
+
+```json
+{ "component": "AgDivider" }
+```
+
+**Why it fails:** every node schema includes `id: z.string()` as a required field.
+
+**Fix:** add a unique kebab-case id: `"id": "divider-1"`.
+
+### Mistake 4: component name that does not exist
+
+```json
+{ "id": "msg-1", "component": "AgTextarea", "label": "Message" }
+```
+
+**Why it fails:** `AgTextarea` is not a valid discriminated union variant. There is no `AgTextarea` component.
+
+**Fix:** use `AgInput` with a `rows` prop for multi-line text:
+
+```json
+{ "id": "msg-1", "component": "AgInput", "label": "Message", "type": "text", "rows": 4 }
+```
+
+---
+
+## Using `agnosticui-schema.json` as LLM context
+
+The file `v2/schema/agnosticui-schema.json` is the machine-readable version of the full Zod schema, emitted by:
+
+```bash
+npm run codegen -- --emit-schema-json
+```
+
+It follows JSON Schema draft-07 and lists every component, every prop, and every valid enum value. Pass it as context in your system prompt when you want the LLM to have precise prop knowledge without relying on the enum list in the template above.
+
+Example: injecting the schema JSON into a system prompt in Node.js:
+
+```ts
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const schemaJson = readFileSync(
+  resolve('v2/schema/agnosticui-schema.json'),
+  'utf-8'
+);
+
+const systemPrompt = `
+You are generating UI node graphs for the AgnosticUI SDUI system.
+Respond ONLY with a JSON code block containing an AgNode[] array.
+
+The full schema for all components is:
+
+\`\`\`json
+${schemaJson}
+\`\`\`
+
+Follow all rules in the schema exactly.
+`;
+```
+
+Keep the schema JSON as close to the start of the context window as possible when budget is constrained. If the full file is too large, consider passing only the definition block for the specific component(s) you need.
+
+---
+
+## Validating the output
+
+```ts
+import { validateGraph } from '@agnosticui/schema';
+import type { AgNode } from '@agnosticui/schema';
+
+function assertValidGraph(nodes: unknown[]): AgNode[] {
+  const result = validateGraph(nodes);
+
+  if (!result.success) {
+    const detail = result.errors
+      .map(e => `  [${e.nodeId}] ${e.errors.join('; ')}`)
+      .join('\n');
+    throw new Error(`Invalid AgNode graph:\n${detail}`);
+  }
+
+  return nodes as AgNode[];
+}
+
+// Usage after receiving LLM output
+const raw: unknown[] = JSON.parse(llmOutput);
+const nodes: AgNode[] = assertValidGraph(raw);
+
+// Now safe to pass to AgDynamicRenderer
+```
+
+`validateGraph()` never throws. It returns `{ success: boolean, errors: GraphNodeError[] }`. Each `GraphNodeError` carries the `nodeId` and an `errors: string[]` with field-path messages from Zod plus any unresolved child ID references.
+
+---
+
+## TODO: Agent runtime discovery (requires #389)
+
+Once the Agent Runtime (#389) lands, the following will be available:
+
+- `listComponents()` — returns all available component names
+- `getComponentSchema(name)` — returns the JSON Schema for a specific component
+
+These will enable dynamic discovery without needing to pass the full schema JSON as context.
+
+---
+
+## Further reading
+
+- [sdui-architecture.md](./sdui-architecture.md) — full system architecture, codegen pipeline, CI gates
+- [schema-coverage.md](./schema-coverage.md) — per-component prop coverage and omission reasons

--- a/v2/docs/sdui-architecture.md
+++ b/v2/docs/sdui-architecture.md
@@ -1,0 +1,325 @@
+# SDUI Architecture
+
+The AgnosticUI Schema-Driven UI (SDUI) system lets developers and LLMs describe interfaces as flat JSON node graphs instead of framework-specific JSX, templates, or HTML. A single `AgNode[]` array can be validated once and rendered by React, Vue, or Lit without modification. This document covers the full stack from the Lit component source files through code generation, schema validation, and framework rendering.
+
+## Overview
+
+```mermaid
+graph TD
+    A["v2/lib/src/components/*/core/_*.ts<br/>(Lit source, *Props interfaces)"]
+    B["codegen.ts + codegen.config.ts<br/>(ts-morph introspection)"]
+    C1["schema.ts (Zod discriminated union)"]
+    C2["types.ts (TypeScript interfaces)"]
+    C3["index.ts (validate + validateGraph)"]
+    C4["AgDynamicRenderer.tsx (React)"]
+    C5["AgDynamicRenderer.ts (Vue)"]
+    C6["AgDynamicRenderer.ts (Lit)"]
+    C7["agnosticui-schema.json (JSON Schema)"]
+    D["AgNode[] graph (author / LLM output)"]
+    E["validateGraph()"]
+    F["AgDynamicRenderer (chosen framework)"]
+    G["DOM"]
+    CI1["CI: check-codegen<br/>(7 generated files)"]
+    CI2["CI: validate-fixtures<br/>(16 tests)"]
+
+    A --> B
+    B --> C1
+    B --> C2
+    B --> C3
+    B --> C4
+    B --> C5
+    B --> C6
+    B --> C7
+    C3 --> E
+    D --> E
+    E --> F
+    F --> G
+    CI1 -.->|"watches v2/lib + v2/schema + v2/renderers"| B
+    CI2 -.->|"watches v2/demo/src/fixtures"| E
+```
+
+---
+
+## Codegen pipeline
+
+`codegen.ts` uses [ts-morph](https://ts-morph.com/) to introspect every `*Props` TypeScript interface exported from `v2/lib/src/components/*/core/_*.ts`. It produces 6 source files plus an optional JSON Schema artifact in a single pass.
+
+### Running codegen
+
+```bash
+# From v2/schema/
+npm run codegen
+
+# Also emit the JSON Schema for LLM/agent use
+npm run codegen -- --emit-schema-json
+```
+
+### What codegen produces
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A["_Button.ts\n_Input.ts\n_Toggle.ts\n... (one per component)"]
+        CC["codegen.config.ts\n(omitConfig, noUndefinedProps,\nrendererSlotConfig,\nactionAliasMap, skipComponents,\nrendererPrimitives)"]
+    end
+
+    subgraph "ts-morph"
+        B["Introspect *Props interfaces\nResolve property types\nDetect function props"]
+    end
+
+    subgraph Output
+        O1["schema.ts"]
+        O2["types.ts"]
+        O3["index.ts"]
+        O4["AgDynamicRenderer.tsx (React)"]
+        O5["AgDynamicRenderer.ts (Vue)"]
+        O6["AgDynamicRenderer.ts (Lit)"]
+        O7["agnosticui-schema.json\n(--emit-schema-json only)"]
+    end
+
+    A --> B
+    CC --> B
+    B --> O1
+    B --> O2
+    B --> O3
+    B --> O4
+    B --> O5
+    B --> O6
+    B --> O7
+```
+
+### codegen.config.ts knobs
+
+| Key | Purpose |
+|---|---|
+| `omitConfig` | Non-function props to exclude per component (runtime state, internal hooks) |
+| `noUndefinedProps` | Props that must use conditional spread in React to avoid attribute removal |
+| `actionAliasMap` | Maps function prop names (`onClick`) to SDUI string aliases (`on_click`) |
+| `actionPayloadMap` | Expression to extract a serializable payload from the event argument |
+| `rendererSlotConfig` | Controls whether a component renders `label-child`, `children`, or `none` |
+| `typeOverrides` | Explicit Zod + TS type for props where auto-detection is wrong or external |
+| `reactPropRenames` | JSX attribute name overrides (e.g. `ariaLabel` becomes `aria-label`) |
+| `skipComponents` | Entire components excluded from all output (require runtime state) |
+| `rendererPrimitives` | Hand-maintained node types with no Lit counterpart (e.g. `AgText`) |
+
+### Skipped components
+
+Components in `skipComponents` are excluded from all generated output because they require controlled runtime state that cannot be expressed in a static node graph. Current exclusions: `Collapsible`, `Combobox`, `Menu`, `Pagination`, `ScrollProgress`, `ScrollToButton`, `Sidebar`, `SidebarNav`, `Slider`, `Toast`, `VisuallyHidden`.
+
+---
+
+## Node graph model
+
+An `AgNode[]` is a flat array of node objects. Each node has a required `id` (unique within the graph) and a required `component` field. All other fields are component-specific props. Container relationships are expressed through `children: string[]`, which holds the IDs of child nodes rather than nested objects.
+
+### Example: a card with a heading and a button
+
+```json
+[
+  {
+    "id": "my-card",
+    "component": "AgCard",
+    "children": ["card-title", "card-action"]
+  },
+  {
+    "id": "card-title",
+    "component": "AgText",
+    "text": "Welcome back",
+    "el": "h2"
+  },
+  {
+    "id": "card-action",
+    "component": "AgButton",
+    "variant": "primary",
+    "children": ["card-action-label"]
+  },
+  {
+    "id": "card-action-label",
+    "component": "AgText",
+    "text": "Get started"
+  }
+]
+```
+
+### Discriminated union
+
+`AgNodeSchema` in `schema.ts` is a Zod `z.discriminatedUnion('component', [...])`. The `component` field is a string literal on every variant (`z.literal('AgButton')`, `z.literal('AgCard')`, etc.). Zod uses the `component` value to select the exact schema variant before validating any other field, which means:
+
+- Type errors are reported against the correct variant's props.
+- An LLM can read `component` and know exactly which props are valid without scanning all variants.
+- TypeScript narrows the union automatically in `switch (node.component)` blocks.
+
+---
+
+## Node graph lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Author as Developer or LLM
+    participant VG as validateGraph()
+    participant R as AgDynamicRenderer
+    participant DOM
+
+    Author->>VG: validateGraph(nodes: unknown[])
+    alt all nodes valid
+        VG-->>Author: { success: true, errors: [] }
+        Author->>R: <AgDynamicRenderer nodes={nodes} actions={actionsMap} />
+        R->>R: Build nodeMap (id → AgNode)
+        R->>R: renderNode() for each root node
+        R-->>DOM: React/Vue/Lit elements
+    else validation failures
+        VG-->>Author: { success: false, errors: [{ nodeId, errors[] }] }
+        Author->>Author: Fix nodes and retry
+    end
+```
+
+`validateGraph()` performs two passes:
+
+1. Each node is validated with `validate()` against the Zod discriminated union schema.
+2. Every string in a node's `children` array is checked against the set of all declared IDs in the graph. Missing refs produce errors with the form `child ref "<id>" not found in graph`.
+
+Errors are returned as `GraphNodeError[]`, each containing the `nodeId` and an array of human-readable messages. The call never throws.
+
+---
+
+## Framework renderers
+
+Three renderer files are generated at `v2/renderers/{react,vue,lit}/src/AgDynamicRenderer.{tsx,ts}`. Each contains:
+
+- A `switch (node.component)` block mapping every component name to its framework wrapper.
+- A `renderChildren(childIds)` helper that resolves IDs from the node map and renders recursively.
+- An `actions` prop: `Record<string, (payload?: unknown) => void>`.
+
+### The `actions` map
+
+SDUI nodes carry string aliases for interactive callbacks (`on_click`, `on_change`, `on_dismiss`, etc.). When the renderer encounters an action alias, it calls `actions[alias]?.(payload)` — only aliases present in the caller's map are invoked. Unknown aliases are silently ignored. No `eval()` or dynamic code execution occurs; this is the XSS boundary.
+
+### `noUndefinedProps` and the @lit/react problem
+
+`@lit/react`'s `createComponent` passes all props through `Object.entries`, which includes entries whose value is `undefined`. For Lit web components that use `reflect: true` `@property` decorators in CSS `:host([size])` attribute selectors, receiving `undefined` removes the reflected attribute. This invalidates the entire CSS custom-property chain at computed value time (IACVT: Invalid At Computed Value Time), breaking component appearance even when the Lit constructor has default values.
+
+The fix is a conditional spread in the generated React renderer:
+
+```tsx
+{...(node.size !== undefined ? { size: node.size } : {})}
+```
+
+This affects only the React renderer because Vue and Lit do not use `@lit/react`. Props requiring this treatment are declared in `noUndefinedProps` in `codegen.config.ts`.
+
+### Renderer primitives
+
+`rendererPrimitives` in `codegen.config.ts` defines hand-maintained node types that have no Lit component counterpart. The only current primitive is `AgText`, which renders to a plain HTML element (`span`, `p`, `h1-h4`, or `label`) with a `text` prop. The codegen appends primitives verbatim after the discovered-component output in every generated file.
+
+---
+
+## CI gates
+
+### check-codegen
+
+**Workflow:** `.github/workflows/check-codegen.yml`
+**Trigger:** push or PR touching `v2/lib/src/components/**`, `v2/schema/**`, or `v2/renderers/**`
+**Command:** `npm run check-codegen` (from `v2/schema/`)
+
+This runs `check-codegen.ts`, which invokes codegen in dry-run mode and compares each of the 7 generated files against what codegen would produce. If any file differs, the step fails with a diff and exits non-zero.
+
+**To fix a drift failure:** run `npm run codegen` (and `npm run codegen -- --emit-schema-json` if `agnosticui-schema.json` drifted), then commit the regenerated files.
+
+### validate-fixtures
+
+**Workflow:** `.github/workflows/validate-fixtures.yml`
+**Trigger:** push or PR touching `v2/schema/**`, `v2/demo/src/fixtures/**`, or `v2/renderers/**`
+**Command:** `npm test` (from `v2/demo/`)
+
+Runs Vitest against `fixtures.spec.ts`, which calls `validateGraph()` on every variation in `fixtureBank` plus `pickerFixture`. Currently covers 16 fixture variations across multiple workflow types (login form, contact form, etc.).
+
+---
+
+## File layout
+
+```
+v2/
+  lib/
+    src/components/          One directory per component
+      Button/core/_Button.ts   Source of truth: ButtonProps interface
+      Input/core/_Input.ts
+      Toggle/core/_Toggle.ts
+      ...                    (57 total component directories)
+
+  schema/                    @agnosticui/schema package
+    src/
+      schema.ts              Zod discriminated union (AgNodeSchema) — AUTO-GENERATED
+      types.ts               TypeScript interfaces (AgNode, AgButtonNode, etc.) — AUTO-GENERATED
+      validate.ts            validate() + validateGraph() — hand-maintained
+      index.ts               Public exports — AUTO-GENERATED
+    scripts/
+      codegen.ts             ts-morph introspection + file generator
+      codegen.config.ts      omitConfig, noUndefinedProps, rendererSlotConfig, etc.
+      check-codegen.ts       Dry-run diff used by CI
+      emit-schema-json.ts    JSON Schema output (--emit-schema-json flag)
+    agnosticui-schema.json   JSON Schema for LLM/agent use — AUTO-GENERATED
+
+  renderers/
+    react/src/AgDynamicRenderer.tsx   React renderer — AUTO-GENERATED
+    vue/src/AgDynamicRenderer.ts      Vue renderer — AUTO-GENERATED
+    lit/src/AgDynamicRenderer.ts      Lit renderer — AUTO-GENERATED
+
+  demo/                      React Vite demonstration app
+    src/
+      fixtures/
+        index.ts             fixtureBank (AgNode[][] per workflow type)
+        picker.ts            pickerFixture (WorkflowPicker graph)
+        fixtures.spec.ts     Vitest: validateGraph() on all fixture variations
+      components/
+        WorkflowPicker/      SelectionCardGroup for choosing a fixture
+        StreamingOutput/     Live renderer output panel
+
+  docs/                      Developer guides (this file lives here)
+    sdui-architecture.md
+    schema-coverage.md
+    llm-prompt-guide.md
+
+  skins/                     CSS custom property token bundles
+  site/                      VitePress documentation site
+  playbooks/                 AI prompt-driven example apps
+```
+
+---
+
+## Key design decisions
+
+### Flat ID-ref graph instead of nested objects
+
+Each node is independently addressable by `id`. Keeping the graph flat means:
+
+- `validateGraph()` can check all ID references in a single pass without recursive descent.
+- An LLM generating a graph can append or remove a node without restructuring the whole tree.
+- Serialization and diffing are trivial (it is a plain JSON array).
+- The renderer does the lookup at render time: `nodeMap.get(childId)`.
+
+### Zod discriminated union
+
+`z.discriminatedUnion('component', [...])` was chosen over a single `z.union([...])` because Zod can select the correct variant branch using `component` before validating any other field. This produces precise error messages pointing to the exact prop and variant, rather than a wall of "did not match any union variant" noise.
+
+### noUndefinedProps and IACVT
+
+The `@lit/react` `createComponent` wrapper passes all React props to the underlying custom element via `Object.entries`. When a prop is `undefined`, `Object.entries` still includes it, and the wrapper calls `element.removeAttribute(name)`. For props that Lit uses in reflected attribute CSS selectors (`:host([size])`), this removes the attribute even when the Lit constructor has a default. The resulting IACVT error silently breaks the custom-property transform chain. The conditional spread pattern (`{...(node.prop !== undefined ? { prop: node.prop } : {})}`) avoids this. Only React is affected; Vue and Lit renderers are not mediated by `@lit/react`.
+
+### actionAliasMap
+
+Function-typed props are not serializable and cannot live in JSON. The `actionAliasMap` translates each event handler name to a stable snake_case alias stored as a plain string on the node. The renderer maps aliases back to callbacks at runtime via the `actions` object passed by the application. Function props not present in `actionAliasMap` are silently dropped from the schema.
+
+### Source copy, not npm-only for renderers
+
+The three `AgDynamicRenderer` files are generated into the repo and checked in. This means:
+
+- CI can detect drift between the Lit source and the renderer output.
+- Consumers get a fully typed, auditable file rather than a black-box npm artifact.
+- The check-codegen workflow catches any manual edits that would be overwritten on the next codegen run.
+
+---
+
+## Further reading
+
+- [schema-coverage.md](./schema-coverage.md) — per-component prop coverage status and omission reasons
+- [llm-prompt-guide.md](./llm-prompt-guide.md) — practical guide to prompting LLMs to emit valid `AgNode[]` graphs
+- [Root README](../../README.md) — project-level overview and quick-start


### PR DESCRIPTION
## Summary

Two new developer docs shipped together, cross-referenced, and linked from the root README.

### #402 — `v2/docs/sdui-architecture.md`
Developer-facing architecture guide with:
- **System overview** Mermaid `graph TD`: Lit source → codegen → schema/renderers/JSON → validateGraph → DOM, with CI gate annotations
- **Codegen pipeline** Mermaid `flowchart LR`: inputs (Lit `_*.ts` + `codegen.config.ts`), ts-morph introspection, 7 output files
- **Node graph model**: flat ID-ref array, discriminated union explanation, JSON example
- **Node graph lifecycle** Mermaid `sequenceDiagram`: happy path + error path through `validateGraph()`
- **Framework renderers**: `actions` map, `noUndefinedProps`/IACVT explanation (React-only), renderer primitives
- **CI gates**: both `check-codegen` (7 files) and `validate-fixtures` (16 tests) with fix instructions
- **File layout**: annotated `v2/` directory tree
- **Key design decisions**: flat graph vs nested, Zod discriminated union, noUndefinedProps, actionAliasMap, source-copy for renderers

### #393 — `v2/docs/llm-prompt-guide.md`
LLM-facing practical guide with:
- Copy-paste system prompt template (valid component list, flat graph rules, AgText usage, action aliases, enum constraints)
- Few-shot example 1: complete valid login form `AgNode[]`
- Few-shot example 2: 4 annotated rejection cases (bad enum, nested children, missing id, unknown component name)
- `agnosticui-schema.json` injection pattern for Node.js
- `assertValidGraph()` helper snippet
- TODO stub for `listComponents()` / `getComponentSchema()` (requires #389)

### README.md
Single schema-coverage link replaced with three-bullet list covering all three companion docs.

## Test plan

- [ ] Both markdown files render correctly in GitHub (Mermaid diagrams appear as diagrams, not raw text)
- [ ] All cross-links between the three docs resolve correctly
- [ ] README links resolve correctly
- [ ] CI passes (docs-only change, no generated files touched)

## Closes #393, #402