### PR TITLE
fix(demo-react): dedupe react to prevent dual-instance error on Netlify

### DIFF
--- a/v2/demo/vite.config.ts
+++ b/v2/demo/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   optimizeDeps: {
     noDiscovery: true,
     holdUntilCrawlEnd: false,


### PR DESCRIPTION
## Summary

The Netlify build runs `npm ci --ignore-scripts` in `v2/renderers/react`, which installs its own `node_modules/react`. Vite then bundles two React instances — one from the renderer and one from the demo — causing the `Cannot read properties of null (reading 'useRef')` crash.

Adds `resolve.dedupe: ['react', 'react-dom']` to `v2/demo/vite.config.ts` so Vite always collapses both to the demo's single copy.

## Test plan

- [ ] Netlify deploy of `agnosticui-demo-react.netlify.app` loads without errors