### PR TITLE
fix(deploy): install demo deps before vue/lit Netlify builds for shared fixture resolution

### DIFF
--- a/v2/demo-lit/netlify.toml
+++ b/v2/demo-lit/netlify.toml
@@ -2,6 +2,7 @@
   command = """
     (cd ../lib && npm ci --ignore-scripts && npm run build:no-sync) &&
     (cd ../schema && npm ci && npm run build) &&
+    (cd ../demo && npm ci --ignore-scripts) &&
     (cd ../renderers/lit && npm ci --ignore-scripts && npm run build) &&
     npm ci --ignore-scripts &&
     npm run build

--- a/v2/demo-vue/netlify.toml
+++ b/v2/demo-vue/netlify.toml
@@ -2,6 +2,7 @@
   command = """
     (cd ../lib && npm ci --ignore-scripts && npm run build:no-sync) &&
     (cd ../schema && npm ci && npm run build) &&
+    (cd ../demo && npm ci --ignore-scripts) &&
     (cd ../renderers/vue && npm ci --ignore-scripts && npm run build) &&
     npm ci --ignore-scripts &&
     npm run build


### PR DESCRIPTION
## Summary

The Vue and Lit demos reference shared fixtures from `../demo/src/fixtures/`. When `vue-tsc`/`tsc` type-checks those cross-directory files, it walks up from `v2/demo/` to resolve `@agnosticui/schema` — but `v2/demo/node_modules/` didn't exist on the Netlify build, causing TS2307 errors.

Fix: add `(cd ../demo && npm ci --ignore-scripts)` to both `netlify.toml` build sequences, ensuring `v2/demo/node_modules/@agnosticui/schema` exists before the renderer and demo builds run.

## Test plan

- [ ] Netlify deploy preview for `agnosticui-demo-vue` builds and loads without errors
- [ ] Netlify deploy preview for `agnosticui-demo-lit` builds and loads without errors