### PR TITLE
feat(sdui-demos): spec, dark mode/skin switcher, and step flows (#413…

### DIFF
--- a/v2/demo-lit/index.html
+++ b/v2/demo-lit/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AgnosticUI — SDUI Demo (Lit)</title>
+    <script>
+      if (localStorage.getItem('ag-theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
   </head>
   <body>
     <ag-sdui-demo></ag-sdui-demo>

--- a/v2/demo-lit/src/AgSduiDemo.ts
+++ b/v2/demo-lit/src/AgSduiDemo.ts
@@ -3,6 +3,7 @@ import { state } from 'lit/decorators.js';
 import 'agnosticui-core/header';
 import './components/WorkflowPicker';
 import './components/StreamingOutput';
+import './SkinSwitcher';
 
 export class AgSduiDemo extends LitElement {
   static styles = css`
@@ -99,6 +100,7 @@ export class AgSduiDemo extends LitElement {
           </div>
         </section>
       </div>
+      <skin-switcher></skin-switcher>
     `;
   }
 }

--- a/v2/demo-lit/src/SkinSwitcher.ts
+++ b/v2/demo-lit/src/SkinSwitcher.ts
@@ -1,0 +1,312 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import {
+  SKINS,
+  applySkin,
+  applyTheme,
+  restorePrefs,
+  copySkinCSS,
+} from '../../skins/skin-switcher-core.js';
+
+// Restore on load
+restorePrefs();
+
+@customElement('skin-switcher')
+export class SkinSwitcher extends LitElement {
+  @state() private _open = false;
+  @state() private _skin = localStorage.getItem('ag-skin') || '';
+  @state() private _dark = document.documentElement.getAttribute('data-theme') === 'dark';
+  @state() private _copiedId: string | null = null;
+
+  private _onClickOutside = (e: MouseEvent) => {
+    if (!this._open) return;
+    const path = e.composedPath();
+    if (!path.includes(this)) {
+      this._open = false;
+    }
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('mousedown', this._onClickOutside);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('mousedown', this._onClickOutside);
+  }
+
+  private _setSkin(id: string) {
+    this._skin = id;
+    applySkin(id);
+  }
+
+  private _setTheme(dark: boolean) {
+    this._dark = dark;
+    applyTheme(dark);
+  }
+
+  private async _handleCopy(e: Event, skinId: string) {
+    e.stopPropagation();
+    const ok = await copySkinCSS(skinId);
+    if (ok) {
+      this._copiedId = skinId;
+      setTimeout(() => { this._copiedId = null; }, 1500);
+    }
+  }
+
+  render() {
+    return html`
+      ${this._open ? html`
+        <div class="skin-panel">
+          <div class="skin-panel-section">
+            <div class="skin-panel-label">Theme</div>
+            <div class="skin-panel-themes">
+              <button class="skin-theme-btn ${!this._dark ? 'active' : ''}" @click=${() => this._setTheme(false)}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+                Light
+              </button>
+              <button class="skin-theme-btn ${this._dark ? 'active' : ''}" @click=${() => this._setTheme(true)}>
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+                Dark
+              </button>
+            </div>
+          </div>
+          <div class="skin-panel-section">
+            <div class="skin-panel-label">Skin</div>
+            ${SKINS.map(s => html`
+              <button class="skin-option ${this._skin === s.id ? 'active' : ''}" @click=${() => this._setSkin(s.id)}>
+                <span class="skin-option-radio"></span>
+                <span class="skin-option-label">${s.label}</span>
+                <span class="skin-option-swatch" style="background:${s.swatch}"></span>
+                ${s.id ? html`
+                  <span class="skin-option-copy" role="button" tabindex="0" title="Copy CSS" @click=${(e: Event) => this._handleCopy(e, s.id)}>
+                    ${this._copiedId === s.id
+                      ? html`<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>`
+                      : html`<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`}
+                  </span>
+                ` : ''}
+              </button>
+            `)}
+          </div>
+        </div>
+      ` : ''}
+      <button class="skin-fab" @click=${() => { this._open = !this._open; }} aria-label="Toggle skin switcher">
+        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="13.5" cy="6.5" r="0.5" fill="currentColor" /><circle cx="17.5" cy="10.5" r="0.5" fill="currentColor" /><circle cx="8.5" cy="7.5" r="0.5" fill="currentColor" /><circle cx="6.5" cy="12" r="0.5" fill="currentColor" />
+          <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2Z"/>
+        </svg>
+      </button>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+
+    .skin-fab {
+      position: fixed;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      z-index: 9999;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: 1px solid var(--ag-border, #e0e0e0);
+      background: var(--ag-background-primary, #ffffff);
+      color: var(--ag-text-secondary, #666);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: var(--ag-shadow-lg, 0 4px 16px -2px rgba(0, 0, 0, 0.12));
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .skin-fab:hover {
+      transform: scale(1.08);
+      box-shadow: var(--ag-shadow-xl, 0 8px 24px -4px rgba(0, 0, 0, 0.16));
+    }
+
+    .skin-fab:active {
+      transform: scale(0.96);
+    }
+
+    .skin-fab svg {
+      width: 22px;
+      height: 22px;
+      pointer-events: none;
+    }
+
+    .skin-panel {
+      position: fixed;
+      bottom: 5rem;
+      right: 1.5rem;
+      z-index: 9999;
+      width: 240px;
+      background: var(--ag-background-primary, #ffffff);
+      border: 1px solid var(--ag-border, #e0e0e0);
+      border-radius: var(--ag-radius-md, 0.5rem);
+      box-shadow: var(--ag-shadow-xl, 0 8px 24px -4px rgba(0, 0, 0, 0.16));
+      padding: 0;
+      overflow: hidden;
+      animation: skin-panel-in 0.15s ease-out;
+    }
+
+    @keyframes skin-panel-in {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .skin-panel-section {
+      padding: 0.75rem 1rem;
+    }
+
+    .skin-panel-section + .skin-panel-section {
+      border-top: 1px solid var(--ag-border, #e0e0e0);
+    }
+
+    .skin-panel-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--ag-text-secondary, #666);
+      margin: 0 0 0.5rem 0;
+    }
+
+    .skin-panel-themes {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .skin-theme-btn {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.5rem;
+      border: 1px solid var(--ag-border, #e0e0e0);
+      border-radius: var(--ag-radius-sm, 0.25rem);
+      background: transparent;
+      color: var(--ag-text-secondary, #666);
+      font-size: 0.8125rem;
+      font-family: inherit;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+
+    .skin-theme-btn:hover {
+      background: var(--ag-background-secondary, #f5f5f5);
+    }
+
+    .skin-theme-btn.active {
+      background: var(--ag-primary-background, #e8f0fe);
+      border-color: var(--ag-primary, #297aff);
+      color: var(--ag-primary, #297aff);
+      font-weight: 600;
+    }
+
+    .skin-theme-btn svg {
+      width: 14px;
+      height: 14px;
+      pointer-events: none;
+    }
+
+    .skin-option {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      width: 100%;
+      padding: 0.4375rem 0.25rem;
+      border: none;
+      background: transparent;
+      color: var(--ag-text-primary, #1a1a1a);
+      font-size: 0.8125rem;
+      font-family: inherit;
+      cursor: pointer;
+      border-radius: var(--ag-radius-sm, 0.25rem);
+      transition: background 0.15s;
+    }
+
+    .skin-option:hover {
+      background: var(--ag-background-secondary, #f5f5f5);
+    }
+
+    .skin-option.active {
+      font-weight: 600;
+      color: var(--ag-primary, #297aff);
+    }
+
+    .skin-option-radio {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      border: 2px solid var(--ag-border, #ccc);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .skin-option.active .skin-option-radio {
+      border-color: var(--ag-primary, #297aff);
+    }
+
+    .skin-option.active .skin-option-radio::after {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--ag-primary, #297aff);
+    }
+
+    .skin-option-label {
+      flex: 1;
+      text-align: left;
+    }
+
+    .skin-option-swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      border: 1px solid rgba(0, 0, 0, 0.1);
+    }
+
+    .skin-option-copy {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 22px;
+      padding: 0;
+      border: none;
+      border-radius: var(--ag-radius-sm, 0.25rem);
+      background: transparent;
+      color: var(--ag-text-secondary, #999);
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: color 0.15s, background 0.15s;
+    }
+
+    .skin-option-copy:hover {
+      color: var(--ag-text-primary, #1a1a1a);
+      background: var(--ag-background-secondary, #f0f0f0);
+    }
+
+    .skin-option-copy svg {
+      width: 13px;
+      height: 13px;
+      pointer-events: none;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'skin-switcher': SkinSwitcher;
+  }
+}

--- a/v2/demo-lit/src/components/StreamingOutput.ts
+++ b/v2/demo-lit/src/components/StreamingOutput.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import '@agnosticui/render-lit';
 import type { AgNode } from '@agnosticui/schema';
-import { pickVariation } from '../../../demo/src/fixtures/index';
+import { pickVariation, confirmFixtures, workflowActions } from '../../../demo/src/fixtures/index';
 import { streamFixture } from '../../../demo/src/lib/stream';
 
 export class StreamingOutput extends LitElement {
@@ -32,30 +32,47 @@ export class StreamingOutput extends LitElement {
   @property({ type: Number }) seed = 0;
 
   @state() private nodes: AgNode[] = [];
+  @state() private actions: Record<string, () => void> = {};
 
   private cancelStream: (() => void) | null = null;
 
-  private async startStream(workflow: string) {
+  private async runStream(fixture: AgNode[]) {
     if (this.cancelStream) this.cancelStream();
     let cancelled = false;
     this.cancelStream = () => { cancelled = true; };
     this.nodes = [];
-    const fixture = pickVariation(workflow);
     for await (const node of streamFixture(fixture)) {
       if (cancelled) break;
       this.nodes = [...this.nodes, node];
     }
   }
 
+  private buildActions(workflow: string): Record<string, () => void> {
+    const aliases = workflowActions[workflow] ?? {};
+    const map: Record<string, () => void> = {};
+    for (const [alias, confirmKey] of Object.entries(aliases)) {
+      map[alias] = () => {
+        const fixture = confirmFixtures[confirmKey];
+        if (fixture) this.runStream(fixture);
+      };
+    }
+    return map;
+  }
+
+  private startWorkflow(workflow: string) {
+    this.actions = this.buildActions(workflow);
+    this.runStream(pickVariation(workflow));
+  }
+
   override updated(changed: Map<string, unknown>) {
     if (changed.has('workflow') || changed.has('seed')) {
-      this.startStream(this.workflow);
+      this.startWorkflow(this.workflow);
     }
   }
 
   override connectedCallback() {
     super.connectedCallback();
-    this.startStream(this.workflow);
+    this.startWorkflow(this.workflow);
   }
 
   override disconnectedCallback() {
@@ -64,7 +81,7 @@ export class StreamingOutput extends LitElement {
   }
 
   render() {
-    return html`<ag-dynamic-renderer .nodes=${this.nodes}></ag-dynamic-renderer>`;
+    return html`<ag-dynamic-renderer .nodes=${this.nodes} .actions=${this.actions}></ag-dynamic-renderer>`;
   }
 }
 

--- a/v2/demo-lit/src/main.ts
+++ b/v2/demo-lit/src/main.ts
@@ -1,5 +1,6 @@
 import 'agnosticui-core/styles/tokens.css';
 import 'agnosticui-core/styles/tokens-dark.css';
 import '../../skins/skins-bundle.css';
+import '../../skins/skin-switcher.css';
 import './index.css';
 import './AgSduiDemo';

--- a/v2/demo-vue/index.html
+++ b/v2/demo-vue/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AgnosticUI — SDUI Demo (Vue)</title>
+    <script>
+      if (localStorage.getItem('ag-theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/v2/demo-vue/src/App.vue
+++ b/v2/demo-vue/src/App.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { VueHeader } from 'agnosticui-core/header/vue';
 import WorkflowPicker from './components/WorkflowPicker.vue';
 import StreamingOutput from './components/StreamingOutput.vue';
+import SkinSwitcher from './SkinSwitcher.vue';
 
 const workflow = ref('contact-form');
 const seed = ref(0);
@@ -45,6 +46,7 @@ const handleRegenerate = () => {
       </div>
     </section>
     </div>
+    <SkinSwitcher />
   </div>
 </template>
 

--- a/v2/demo-vue/src/SkinSwitcher.vue
+++ b/v2/demo-vue/src/SkinSwitcher.vue
@@ -1,0 +1,101 @@
+<template>
+  <div ref="wrapper">
+    <div v-if="open" class="skin-panel">
+      <div class="skin-panel-section">
+        <div class="skin-panel-label">Theme</div>
+        <div class="skin-panel-themes">
+          <button :class="['skin-theme-btn', { active: !dark }]" @click="setTheme(false)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/></svg>
+            Light
+          </button>
+          <button :class="['skin-theme-btn', { active: dark }]" @click="setTheme(true)">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            Dark
+          </button>
+        </div>
+      </div>
+      <div class="skin-panel-section">
+        <div class="skin-panel-label">Skin</div>
+        <button
+          v-for="s in SKINS"
+          :key="s.id"
+          :class="['skin-option', { active: skin === s.id }]"
+          @click="setSkin(s.id)"
+        >
+          <span class="skin-option-radio" />
+          <span class="skin-option-label">{{ s.label }}</span>
+          <span class="skin-option-swatch" :style="{ background: s.swatch }" />
+          <span
+            v-if="s.id"
+            class="skin-option-copy"
+            role="button"
+            tabindex="0"
+            title="Copy CSS"
+            @click.stop="handleCopy(s.id)"
+          >
+            <svg v-if="copiedId === s.id" xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          </span>
+        </button>
+      </div>
+    </div>
+    <button class="skin-fab" aria-label="Toggle skin switcher" @click="open = !open">
+      <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="13.5" cy="6.5" r="0.5" fill="currentColor" /><circle cx="17.5" cy="10.5" r="0.5" fill="currentColor" /><circle cx="8.5" cy="7.5" r="0.5" fill="currentColor" /><circle cx="6.5" cy="12" r="0.5" fill="currentColor" />
+        <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2Z"/>
+      </svg>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+import {
+  SKINS,
+  applySkin,
+  applyTheme,
+  restorePrefs,
+  copySkinCSS,
+} from '../../skins/skin-switcher-core.js';
+
+const open = ref(false);
+const skin = ref(localStorage.getItem('ag-skin') || '');
+const dark = ref(document.documentElement.getAttribute('data-theme') === 'dark');
+const copiedId = ref<string | null>(null);
+const wrapper = ref<HTMLElement | null>(null);
+
+function setSkin(id: string) {
+  skin.value = id;
+  applySkin(id);
+}
+
+function setTheme(isDark: boolean) {
+  dark.value = isDark;
+  applyTheme(isDark);
+}
+
+async function handleCopy(skinId: string) {
+  const ok = await copySkinCSS(skinId);
+  if (ok) {
+    copiedId.value = skinId;
+    setTimeout(() => { copiedId.value = null; }, 1500);
+  }
+}
+
+// Restore prefs on load
+restorePrefs();
+
+function onClickOutside(e: MouseEvent) {
+  if (wrapper.value && !wrapper.value.contains(e.target as Node)) {
+    open.value = false;
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('mousedown', onClickOutside);
+});
+
+onUnmounted(() => {
+  document.removeEventListener('mousedown', onClickOutside);
+});
+</script>

--- a/v2/demo-vue/src/components/StreamingOutput.vue
+++ b/v2/demo-vue/src/components/StreamingOutput.vue
@@ -2,29 +2,50 @@
 import { ref, watch } from 'vue';
 import { AgDynamicRenderer } from '@agnosticui/render-vue';
 import type { AgNode } from '@agnosticui/schema';
-import { pickVariation } from '../../../demo/src/fixtures/index';
+import { pickVariation, confirmFixtures, workflowActions } from '../../../demo/src/fixtures/index';
 import { streamFixture } from '../../../demo/src/lib/stream';
 
 const props = defineProps<{ workflow: string; seed: number }>();
 
 const nodes = ref<AgNode[]>([]);
+const actions = ref<Record<string, () => void>>({});
 
+let cancelCurrentStream: () => void = () => {};
+
+async function runStream(fixture: AgNode[]) {
+  cancelCurrentStream();
+  let cancelled = false;
+  cancelCurrentStream = () => { cancelled = true; };
+  nodes.value = [];
+  for await (const node of streamFixture(fixture)) {
+    if (cancelled) break;
+    nodes.value = [...nodes.value, node];
+  }
+}
+
+// Reset to step 1 when workflow or seed changes.
 watch(
   () => [props.workflow, props.seed] as const,
-  async ([workflow], _prev, onCleanup) => {
-    let cancelled = false;
-    onCleanup(() => { cancelled = true; });
-    nodes.value = [];
-    const fixture = pickVariation(workflow);
-    for await (const node of streamFixture(fixture)) {
-      if (cancelled) break;
-      nodes.value = [...nodes.value, node];
+  ([workflow], _prev, onCleanup) => {
+    onCleanup(() => cancelCurrentStream());
+
+    // Rebuild actions map for the new workflow.
+    const aliases = workflowActions[workflow] ?? {};
+    const map: Record<string, () => void> = {};
+    for (const [alias, confirmKey] of Object.entries(aliases)) {
+      map[alias] = () => {
+        const fixture = confirmFixtures[confirmKey];
+        if (fixture) runStream(fixture);
+      };
     }
+    actions.value = map;
+
+    runStream(pickVariation(workflow));
   },
   { immediate: true },
 );
 </script>
 
 <template>
-  <AgDynamicRenderer :nodes="nodes" />
+  <AgDynamicRenderer :nodes="nodes" :actions="actions" />
 </template>

--- a/v2/demo-vue/src/main.ts
+++ b/v2/demo-vue/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue';
 import 'agnosticui-core/styles/tokens.css';
 import 'agnosticui-core/styles/tokens-dark.css';
 import '../../skins/skins-bundle.css';
+import '../../skins/skin-switcher.css';
 import './index.css';
 import App from './App.vue';
 

--- a/v2/demo/index.html
+++ b/v2/demo/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AgnosticUI — SDUI Demo</title>
+    <script>
+      if (localStorage.getItem('ag-theme') === 'dark')
+        document.documentElement.setAttribute('data-theme', 'dark');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/v2/demo/src/App.tsx
+++ b/v2/demo/src/App.tsx
@@ -3,6 +3,7 @@ import { ReactButton } from 'agnosticui-core/button/react';
 import { ReactHeader } from 'agnosticui-core/header/react';
 import { WorkflowPicker } from './components/WorkflowPicker';
 import { StreamingOutput } from './components/StreamingOutput';
+import { SkinSwitcher } from './SkinSwitcher';
 import './App.css';
 
 export default function App() {
@@ -39,6 +40,7 @@ export default function App() {
         </div>
       </section>
     </div>
+      <SkinSwitcher />
     </>
   );
 }

--- a/v2/demo/src/SkinSwitcher.tsx
+++ b/v2/demo/src/SkinSwitcher.tsx
@@ -1,0 +1,139 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import {
+  SKINS,
+  applySkin,
+  applyTheme,
+  restorePrefs,
+  copySkinCSS,
+} from '../../skins/skin-switcher-core.js';
+
+const paletteIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="13.5" cy="6.5" r="0.5" fill="currentColor" /><circle cx="17.5" cy="10.5" r="0.5" fill="currentColor" /><circle cx="8.5" cy="7.5" r="0.5" fill="currentColor" /><circle cx="6.5" cy="12" r="0.5" fill="currentColor" />
+    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2Z"/>
+  </svg>
+);
+
+const sunIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
+  </svg>
+);
+
+const moonIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+  </svg>
+);
+
+const copyIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+  </svg>
+);
+
+const checkIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M20 6 9 17l-5-5"/>
+  </svg>
+);
+
+// Restore on load
+restorePrefs();
+
+export function SkinSwitcher() {
+  const [open, setOpen] = useState(false);
+  const [skin, setSkin] = useState(() => localStorage.getItem('ag-skin') || '');
+  const [dark, setDark] = useState(
+    () => document.documentElement.getAttribute('data-theme') === 'dark'
+  );
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const toggle = useCallback(() => setOpen(o => !o), []);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  function handleSkin(id: string) {
+    setSkin(id);
+    applySkin(id);
+  }
+
+  function handleTheme(isDark: boolean) {
+    setDark(isDark);
+    applyTheme(isDark);
+  }
+
+  async function handleCopy(e: React.MouseEvent, skinId: string) {
+    e.stopPropagation();
+    const ok = await copySkinCSS(skinId);
+    if (ok) {
+      setCopiedId(skinId);
+      setTimeout(() => setCopiedId(null), 1500);
+    }
+  }
+
+  return (
+    <div ref={panelRef}>
+      {open && (
+        <div className="skin-panel">
+          <div className="skin-panel-section">
+            <div className="skin-panel-label">Theme</div>
+            <div className="skin-panel-themes">
+              <button
+                className={`skin-theme-btn${!dark ? ' active' : ''}`}
+                onClick={() => handleTheme(false)}
+              >
+                {sunIcon} Light
+              </button>
+              <button
+                className={`skin-theme-btn${dark ? ' active' : ''}`}
+                onClick={() => handleTheme(true)}
+              >
+                {moonIcon} Dark
+              </button>
+            </div>
+          </div>
+          <div className="skin-panel-section">
+            <div className="skin-panel-label">Skin</div>
+            {SKINS.map(s => (
+              <button
+                key={s.id}
+                className={`skin-option${skin === s.id ? ' active' : ''}`}
+                onClick={() => handleSkin(s.id)}
+              >
+                <span className="skin-option-radio" />
+                <span className="skin-option-label">{s.label}</span>
+                <span className="skin-option-swatch" style={{ background: s.swatch }} />
+                {s.id && (
+                  <span
+                    className="skin-option-copy"
+                    role="button"
+                    tabIndex={0}
+                    title="Copy CSS"
+                    onClick={(e) => handleCopy(e, s.id)}
+                  >
+                    {copiedId === s.id ? checkIcon : copyIcon}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <button className="skin-fab" onClick={toggle} aria-label="Toggle skin switcher">
+        {paletteIcon}
+      </button>
+    </div>
+  );
+}

--- a/v2/demo/src/components/StreamingOutput.tsx
+++ b/v2/demo/src/components/StreamingOutput.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { AgNode } from '@agnosticui/schema';
 import { AgDynamicRenderer } from '@agnosticui/render-react';
-import { pickVariation } from '../fixtures/index';
+import { pickVariation, confirmFixtures, workflowActions } from '../fixtures/index';
 import { streamFixture } from '../lib/stream';
 
 interface StreamingOutputProps {
@@ -11,19 +11,34 @@ interface StreamingOutputProps {
 
 export function StreamingOutput({ workflow, seed }: StreamingOutputProps) {
   const [nodes, setNodes] = useState<AgNode[]>([]);
+  const cancelRef = useRef<() => void>(() => {});
 
-  useEffect(() => {
-    setNodes([]);
-    const fixture = pickVariation(workflow);
+  const runStream = useCallback(async (fixture: AgNode[]) => {
+    cancelRef.current();
     let cancelled = false;
-    (async () => {
-      for await (const node of streamFixture(fixture)) {
-        if (cancelled) break;
-        setNodes(prev => [...prev, node]);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [workflow, seed]);
+    cancelRef.current = () => { cancelled = true; };
+    setNodes([]);
+    for await (const node of streamFixture(fixture)) {
+      if (cancelled) break;
+      setNodes(prev => [...prev, node]);
+    }
+  }, []);
 
-  return <AgDynamicRenderer nodes={nodes} />;
+  // Reset to step 1 when workflow or seed changes.
+  useEffect(() => {
+    runStream(pickVariation(workflow));
+    return () => cancelRef.current();
+  }, [workflow, seed, runStream]);
+
+  // Build the actions map: each alias swaps to its confirmation fixture.
+  const aliases = workflowActions[workflow] ?? {};
+  const actions: Record<string, () => void> = {};
+  for (const [alias, confirmKey] of Object.entries(aliases)) {
+    actions[alias] = () => {
+      const fixture = confirmFixtures[confirmKey];
+      if (fixture) runStream(fixture);
+    };
+  }
+
+  return <AgDynamicRenderer nodes={nodes} actions={actions} />;
 }

--- a/v2/demo/src/fixtures/index.ts
+++ b/v2/demo/src/fixtures/index.ts
@@ -7,7 +7,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'cf1-name',         component: 'AgInput',  label: 'Full name',    type: 'text',     placeholder: 'Jane Smith',          required: true, rounded: true },
       { id: 'cf1-email',        component: 'AgInput',  label: 'Email',        type: 'email',    placeholder: 'jane@example.com',    required: true, rounded: true },
       { id: 'cf1-msg',          component: 'AgInput',  label: 'Message',      type: 'text',     placeholder: 'How can we help?',    rows: 4, rounded: true },
-      { id: 'cf1-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', children: ['cf1-submit-label'] },
+      { id: 'cf1-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', on_click: 'SUBMIT_FORM', children: ['cf1-submit-label'] },
       { id: 'cf1-submit-label', component: 'AgText',   text: 'Send message' },
     ],
     // variation 2 — with phone + subject
@@ -17,7 +17,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'cf2-phone',        component: 'AgInput',  label: 'Phone',        type: 'tel',      placeholder: '+1 555 000 0000', rounded: true },
       { id: 'cf2-subject',      component: 'AgInput',  label: 'Subject',      type: 'text',     placeholder: 'How can we help?',    required: true, rounded: true },
       { id: 'cf2-msg',          component: 'AgInput',  label: 'Message',      type: 'text',     placeholder: 'Tell us more...',     rows: 5, rounded: true },
-      { id: 'cf2-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', children: ['cf2-submit-label'] },
+      { id: 'cf2-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', on_click: 'SUBMIT_FORM', children: ['cf2-submit-label'] },
       { id: 'cf2-submit-label', component: 'AgText',   text: 'Submit' },
     ],
     // variation 3 — with newsletter opt-in
@@ -27,7 +27,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'cf3-msg',          component: 'AgInput',  label: 'Message',      type: 'text',     placeholder: 'How can we help?',    rows: 4, rounded: true },
       { id: 'cf3-newsletter',   component: 'AgToggle', label: 'Send me updates and news' },
       { id: 'cf3-divider',      component: 'AgDivider' },
-      { id: 'cf3-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', children: ['cf3-submit-label'] },
+      { id: 'cf3-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', on_click: 'SUBMIT_FORM', children: ['cf3-submit-label'] },
       { id: 'cf3-submit-label', component: 'AgText',   text: 'Get in touch' },
     ],
     // variation 4 — with company + priority
@@ -36,7 +36,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'cf4-company',      component: 'AgInput',  label: 'Company',      type: 'text',     placeholder: 'Acme Corp', rounded: true },
       { id: 'cf4-email',        component: 'AgInput',  label: 'Work email',   type: 'email',    placeholder: 'jane@acme.com',       required: true, rounded: true },
       { id: 'cf4-msg',          component: 'AgInput',  label: 'Message',      type: 'text',     placeholder: 'Describe your issue', rows: 4, rounded: true },
-      { id: 'cf4-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', children: ['cf4-submit-label'] },
+      { id: 'cf4-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', on_click: 'SUBMIT_FORM', children: ['cf4-submit-label'] },
       { id: 'cf4-submit-label', component: 'AgText',   text: 'Send request' },
     ],
     // variation 5 — with badge heading + divider
@@ -48,7 +48,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'cf5-name',         component: 'AgInput',  label: 'Full name',    type: 'text',     placeholder: 'Jane Smith',          required: true, rounded: true },
       { id: 'cf5-email',        component: 'AgInput',  label: 'Email',        type: 'email',    placeholder: 'jane@example.com',    required: true, rounded: true },
       { id: 'cf5-msg',          component: 'AgInput',  label: 'Message',      type: 'text',     placeholder: 'How can we help?',    rows: 4, rounded: true },
-      { id: 'cf5-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', fullWidth: true, children: ['cf5-submit-label'] },
+      { id: 'cf5-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', fullWidth: true, on_click: 'SUBMIT_FORM', children: ['cf5-submit-label'] },
       { id: 'cf5-submit-label', component: 'AgText',   text: 'Send message' },
     ],
   ],
@@ -59,7 +59,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'lf1-email',        component: 'AgInput',  label: 'Email',        type: 'email',    placeholder: 'you@example.com',  required: true, rounded: true },
       { id: 'lf1-password',     component: 'AgInput',  label: 'Password',     type: 'password', required: true, rounded: true },
       { id: 'lf1-remember',     component: 'AgToggle', label: 'Remember me' },
-      { id: 'lf1-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', children: ['lf1-submit-label'] },
+      { id: 'lf1-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', on_click: 'SUBMIT_LOGIN', children: ['lf1-submit-label'] },
       { id: 'lf1-submit-label', component: 'AgText',   text: 'Sign in' },
     ],
     // variation 2 — with forgot password link
@@ -69,7 +69,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'lf2-password',     component: 'AgInput',  label: 'Password',     type: 'password', required: true, rounded: true },
       { id: 'lf2-forgot',       component: 'AgLink',   href: '#',             children: ['lf2-forgot-text'] },
       { id: 'lf2-forgot-text',  component: 'AgText',   text: 'Forgot password?' },
-      { id: 'lf2-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', fullWidth: true, children: ['lf2-submit-label'] },
+      { id: 'lf2-submit',       component: 'AgButton', variant: 'primary',    type: 'submit',   shape: 'rounded', fullWidth: true, on_click: 'SUBMIT_LOGIN', children: ['lf2-submit-label'] },
       { id: 'lf2-submit-label', component: 'AgText',   text: 'Sign in' },
     ],
     // variation 3 — with divider and alternate copy
@@ -77,7 +77,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'lf3-email',        component: 'AgInput',  label: 'Email address', type: 'email',   placeholder: 'you@example.com',  required: true, rounded: true },
       { id: 'lf3-password',     component: 'AgInput',  label: 'Password',      type: 'password', required: true, rounded: true },
       { id: 'lf3-divider',      component: 'AgDivider' },
-      { id: 'lf3-submit',       component: 'AgButton', variant: 'primary',     type: 'submit',  shape: 'rounded', children: ['lf3-submit-label'] },
+      { id: 'lf3-submit',       component: 'AgButton', variant: 'primary',     type: 'submit',  shape: 'rounded', on_click: 'SUBMIT_LOGIN', children: ['lf3-submit-label'] },
       { id: 'lf3-submit-label', component: 'AgText',   text: 'Log in to your account' },
     ],
     // variation 4 — with terms checkbox
@@ -85,7 +85,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'lf4-email',        component: 'AgInput',    label: 'Email',    type: 'email',    placeholder: 'you@example.com',           required: true, rounded: true },
       { id: 'lf4-password',     component: 'AgInput',    label: 'Password', type: 'password', required: true, rounded: true },
       { id: 'lf4-terms',        component: 'AgCheckbox', name: 'terms',     value: 'agreed',  labelText: 'I agree to the terms of service', required: true },
-      { id: 'lf4-submit',       component: 'AgButton',   variant: 'primary', type: 'submit',  shape: 'rounded', children: ['lf4-submit-label'] },
+      { id: 'lf4-submit',       component: 'AgButton',   variant: 'primary', type: 'submit',  shape: 'rounded', on_click: 'SUBMIT_LOGIN', children: ['lf4-submit-label'] },
       { id: 'lf4-submit-label', component: 'AgText',     text: 'Create account' },
     ],
     // variation 5 — with badge + full-width button
@@ -95,7 +95,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'lf5-email',        component: 'AgInput',  label: 'Email',      type: 'email',    placeholder: 'you@example.com', required: true, rounded: true },
       { id: 'lf5-password',     component: 'AgInput',  label: 'Password',   type: 'password', required: true, rounded: true },
       { id: 'lf5-remember',     component: 'AgToggle', label: 'Stay signed in' },
-      { id: 'lf5-submit',       component: 'AgButton', variant: 'primary',  type: 'submit',   shape: 'rounded', fullWidth: true, children: ['lf5-submit-label'] },
+      { id: 'lf5-submit',       component: 'AgButton', variant: 'primary',  type: 'submit',   shape: 'rounded', fullWidth: true, on_click: 'SUBMIT_LOGIN', children: ['lf5-submit-label'] },
       { id: 'lf5-submit-label', component: 'AgText',   text: 'Sign in' },
     ],
   ],
@@ -109,7 +109,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'pc1-title',       component: 'AgText',    text: 'Pro plan',    el: 'h2' },
       { id: 'pc1-price',       component: 'AgText',    text: '$12 / month', el: 'p' },
       { id: 'pc1-divider',     component: 'AgDivider' },
-      { id: 'pc1-cta',         component: 'AgButton',  variant: 'primary',  shape: 'rounded', fullWidth: true, children: ['pc1-cta-label'] },
+      { id: 'pc1-cta',         component: 'AgButton',  variant: 'primary',  shape: 'rounded', fullWidth: true, on_click: 'START_TRIAL', children: ['pc1-cta-label'] },
       { id: 'pc1-cta-label',   component: 'AgText',    text: 'Get started' },
     ],
     // variation 2 — Starter plan
@@ -119,7 +119,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'pc2-price',       component: 'AgText',    text: '$5 / month',  el: 'p' },
       { id: 'pc2-desc',        component: 'AgText',    text: 'Perfect for individuals and small projects', el: 'p' },
       { id: 'pc2-divider',     component: 'AgDivider' },
-      { id: 'pc2-cta',         component: 'AgButton',  bordered: true,      shape: 'rounded', fullWidth: true, children: ['pc2-cta-label'] },
+      { id: 'pc2-cta',         component: 'AgButton',  bordered: true,      shape: 'rounded', fullWidth: true, on_click: 'START_TRIAL', children: ['pc2-cta-label'] },
       { id: 'pc2-cta-label',   component: 'AgText',    text: 'Start free trial' },
     ],
     // variation 3 — Enterprise
@@ -130,7 +130,7 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'pc3-title',       component: 'AgText',    text: 'Custom pricing', el: 'h2' },
       { id: 'pc3-price',       component: 'AgText',    text: 'Contact us',  el: 'p' },
       { id: 'pc3-divider',     component: 'AgDivider' },
-      { id: 'pc3-cta',         component: 'AgButton',  variant: 'primary',  shape: 'rounded', fullWidth: true, children: ['pc3-cta-label'] },
+      { id: 'pc3-cta',         component: 'AgButton',  variant: 'primary',  shape: 'rounded', fullWidth: true, on_click: 'START_TRIAL', children: ['pc3-cta-label'] },
       { id: 'pc3-cta-label',   component: 'AgText',    text: 'Talk to sales' },
     ],
     // variation 4 — Annual plan
@@ -140,24 +140,91 @@ export const fixtureBank: Record<string, AgNode[][]> = {
       { id: 'pc4-badge-text',  component: 'AgText',    text: 'Save 20%' },
       { id: 'pc4-title',       component: 'AgText',    text: 'Annual plan',   el: 'h2' },
       { id: 'pc4-price',       component: 'AgText',    text: '$99 / year',    el: 'p' },
-      { id: 'pc4-saving',      component: 'AgText',    text: 'Billed annually — that\'s $8.25/mo', el: 'p' },
+      { id: 'pc4-saving',      component: 'AgText',    text: 'Billed annually, that\'s $8.25/mo', el: 'p' },
       { id: 'pc4-divider',     component: 'AgDivider' },
-      { id: 'pc4-cta',         component: 'AgButton',  variant: 'primary',    shape: 'rounded', fullWidth: true, children: ['pc4-cta-label'] },
+      { id: 'pc4-cta',         component: 'AgButton',  variant: 'primary',    shape: 'rounded', fullWidth: true, on_click: 'START_TRIAL', children: ['pc4-cta-label'] },
       { id: 'pc4-cta-label',   component: 'AgText',    text: 'Get annual plan' },
     ],
-    // variation 5 — Team plan
+    // variation 5 — Team plan (two CTAs: trial + view plans)
     [
       { id: 'pc5-card',        component: 'AgCard',    shadow: true, rounded: 'md', children: ['pc5-title', 'pc5-price', 'pc5-desc', 'pc5-divider', 'pc5-cta-primary', 'pc5-cta-secondary'] },
       { id: 'pc5-title',       component: 'AgText',    text: 'Team plan',       el: 'h2' },
       { id: 'pc5-price',       component: 'AgText',    text: '$8 / user / month', el: 'p' },
-      { id: 'pc5-desc',        component: 'AgText',    text: 'Minimum 5 seats — scales as your team grows', el: 'p' },
+      { id: 'pc5-desc',        component: 'AgText',    text: 'Minimum 5 seats, scales as your team grows', el: 'p' },
       { id: 'pc5-divider',     component: 'AgDivider' },
-      { id: 'pc5-cta-primary',    component: 'AgButton', variant: 'primary',  shape: 'rounded', fullWidth: true, children: ['pc5-cta-primary-label'] },
+      { id: 'pc5-cta-primary',    component: 'AgButton', variant: 'primary',  shape: 'rounded', fullWidth: true, on_click: 'START_TRIAL', children: ['pc5-cta-primary-label'] },
       { id: 'pc5-cta-primary-label', component: 'AgText', text: 'Start team trial' },
-      { id: 'pc5-cta-secondary',   component: 'AgButton', bordered: true,      shape: 'rounded', fullWidth: true, children: ['pc5-cta-secondary-label'] },
+      { id: 'pc5-cta-secondary',   component: 'AgButton', bordered: true,      shape: 'rounded', fullWidth: true, on_click: 'VIEW_PLANS', children: ['pc5-cta-secondary-label'] },
       { id: 'pc5-cta-secondary-label', component: 'AgText', text: 'View all plans' },
     ],
   ],
+};
+
+// Step-2 confirmation fixtures — single screens shown after an action fires.
+// The renderer is stateless; only the node array swaps.
+export const confirmFixtures: Record<string, AgNode[]> = {
+  'contact-form-confirm': [
+    { id: 'cf-ok-alert',    component: 'AgAlert',  variant: 'success', bordered: true, children: ['cf-ok-alert-text'] },
+    { id: 'cf-ok-alert-text', component: 'AgText', text: "You're now signed up! We'll be in touch within 24 hours." },
+    { id: 'cf-ok-card',    component: 'AgCard',   shadow: true, rounded: 'md', children: ['cf-ok-heading', 'cf-ok-body'] },
+    { id: 'cf-ok-heading', component: 'AgText',   text: 'Message received', el: 'h2' },
+    { id: 'cf-ok-body',    component: 'AgText',   text: 'Our team will review your message and get back to you shortly. Check your inbox for a confirmation email.', el: 'p' },
+  ],
+
+  'login-form-confirm': [
+    { id: 'lf-ok-card',    component: 'AgCard',   shadow: true, rounded: 'md', children: ['lf-ok-badge', 'lf-ok-heading', 'lf-ok-body'] },
+    { id: 'lf-ok-badge',   component: 'AgBadge',  variant: 'success', children: ['lf-ok-badge-text'] },
+    { id: 'lf-ok-badge-text', component: 'AgText', text: 'Authenticated' },
+    { id: 'lf-ok-heading', component: 'AgText',   text: 'Welcome back!', el: 'h2' },
+    { id: 'lf-ok-body',    component: 'AgText',   text: "You're now signed in. Redirecting you to your dashboard...", el: 'p' },
+  ],
+
+  'pricing-trial-confirm': [
+    { id: 'tr-ok-alert',    component: 'AgAlert',  variant: 'success', bordered: true, children: ['tr-ok-alert-text'] },
+    { id: 'tr-ok-alert-text', component: 'AgText', text: 'Your 14-day trial has been started!' },
+    { id: 'tr-ok-card',    component: 'AgCard',   shadow: true, rounded: 'md', children: ['tr-ok-heading', 'tr-ok-body', 'tr-ok-divider', 'tr-ok-badge'] },
+    { id: 'tr-ok-heading', component: 'AgText',   text: 'Trial activated', el: 'h2' },
+    { id: 'tr-ok-body',    component: 'AgText',   text: 'Full access is unlocked for 14 days. No credit card required until you upgrade.', el: 'p' },
+    { id: 'tr-ok-divider', component: 'AgDivider' },
+    { id: 'tr-ok-badge',   component: 'AgBadge',  variant: 'info', children: ['tr-ok-badge-text'] },
+    { id: 'tr-ok-badge-text', component: 'AgText', text: 'Expires in 14 days' },
+  ],
+
+  'pricing-plans': [
+    { id: 'pl-heading',    component: 'AgText',   text: 'All plans', el: 'h2' },
+    { id: 'pl-divider',    component: 'AgDivider' },
+    { id: 'pl-starter',    component: 'AgCard',   shadow: true, rounded: 'sm', children: ['pl-starter-title', 'pl-starter-price', 'pl-starter-cta'] },
+    { id: 'pl-starter-title', component: 'AgText', text: 'Starter', el: 'h3' },
+    { id: 'pl-starter-price', component: 'AgText', text: 'Free — up to 3 projects', el: 'p' },
+    { id: 'pl-starter-cta',   component: 'AgButton', bordered: true, shape: 'rounded', fullWidth: true, children: ['pl-starter-cta-label'] },
+    { id: 'pl-starter-cta-label', component: 'AgText', text: 'Get started free' },
+    { id: 'pl-pro',        component: 'AgCard',   shadow: true, rounded: 'sm', children: ['pl-pro-badge', 'pl-pro-title', 'pl-pro-price', 'pl-pro-cta'] },
+    { id: 'pl-pro-badge',  component: 'AgBadge',  variant: 'primary', children: ['pl-pro-badge-text'] },
+    { id: 'pl-pro-badge-text', component: 'AgText', text: 'Most popular' },
+    { id: 'pl-pro-title',  component: 'AgText',   text: 'Pro', el: 'h3' },
+    { id: 'pl-pro-price',  component: 'AgText',   text: '$12 / month', el: 'p' },
+    { id: 'pl-pro-cta',    component: 'AgButton', variant: 'primary', shape: 'rounded', fullWidth: true, children: ['pl-pro-cta-label'] },
+    { id: 'pl-pro-cta-label', component: 'AgText', text: 'Start Pro trial' },
+    { id: 'pl-ent',        component: 'AgCard',   shadow: true, rounded: 'sm', children: ['pl-ent-title', 'pl-ent-price', 'pl-ent-cta'] },
+    { id: 'pl-ent-title',  component: 'AgText',   text: 'Enterprise', el: 'h3' },
+    { id: 'pl-ent-price',  component: 'AgText',   text: 'Custom pricing', el: 'p' },
+    { id: 'pl-ent-cta',    component: 'AgButton', variant: 'monochrome', shape: 'rounded', fullWidth: true, children: ['pl-ent-cta-label'] },
+    { id: 'pl-ent-cta-label', component: 'AgText', text: 'Talk to sales' },
+  ],
+};
+
+// Maps each workflow's action aliases to the confirm fixture key they trigger.
+export const workflowActions: Record<string, Record<string, string>> = {
+  'contact-form': {
+    SUBMIT_FORM: 'contact-form-confirm',
+  },
+  'login-form': {
+    SUBMIT_LOGIN: 'login-form-confirm',
+  },
+  'pricing-card': {
+    START_TRIAL: 'pricing-trial-confirm',
+    VIEW_PLANS:  'pricing-plans',
+  },
 };
 
 export function pickVariation(workflow: string): AgNode[] {

--- a/v2/demo/src/main.tsx
+++ b/v2/demo/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import 'agnosticui-core/styles/tokens.css';
 import 'agnosticui-core/styles/tokens-dark.css';
 import '../../skins/skins-bundle.css';
+import '../../skins/skin-switcher.css';
 import './index.css';
 import App from './App.tsx';
 

--- a/v2/schema/SPECIFICATION.md
+++ b/v2/schema/SPECIFICATION.md
@@ -1,0 +1,432 @@
+# AgnosticUI SDUI Specification — v1
+
+This document is the authoritative reference for the AgnosticUI Server-Driven UI (SDUI) system.
+It covers the node model, validation pipeline, codegen contract, action dispatch semantics, and
+streaming assumptions.
+
+Related files:
+- `v2/schema/README.md` — developer quick-start
+- `v2/schema/SYSTEM_PROMPT.md` — terse LLM tool definition
+- `v2/schema/scripts/codegen.config.ts` — annotated source of design decisions
+
+---
+
+## 1. Node Model
+
+### 1.1 Shape of `AgNode`
+
+Every SDUI node is a plain JSON object (an `AgNode`) with exactly two required fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique identifier within the graph. Scoped per render call; not globally unique. |
+| `component` | `string` (literal) | Selects the component variant. Must be one of the registered names (e.g. `"AgButton"`). |
+
+All other fields are optional and component-specific. Every field must match the Zod schema for its
+component exactly; unknown props cause validation failure (schemas use `.strict()`).
+
+### 1.2 The Discriminated Union
+
+`AgNode` is a TypeScript discriminated union exported from `src/types.ts`:
+
+```ts
+export type AgNode =
+  | AgButtonNode
+  | AgCardNode
+  | AgInputNode
+  | // ... (one member per registered component)
+```
+
+The `component` field is the discriminant. Each member is a separate `Ag*Node` interface with its
+own set of optional props. This means TypeScript (and Zod) can give precise per-component errors
+rather than generic "unexpected prop" messages.
+
+### 1.3 Children Arrays
+
+Container components express nesting through a `children?: string[]` field. The value is an array
+of `id` strings referencing sibling nodes in the same flat array — it is NOT a nested object tree.
+
+```json
+[
+  { "id": "card-1", "component": "AgCard", "shadow": true, "children": ["email-input", "btn-submit"] },
+  { "id": "email-input", "component": "AgInput", "label": "Email", "type": "email" },
+  { "id": "btn-submit", "component": "AgButton", "label": "Submit", "variant": "primary" }
+]
+```
+
+The renderer builds a `Map<id, AgNode>` at render time and resolves references from it. The array
+can therefore be in any order. Nodes not referenced as `children` by any other node are treated as
+roots and rendered in declaration order.
+
+### 1.4 Renderer Primitive: AgText
+
+`AgText` is a renderer-only node type with no AgnosticUI core component counterpart. It renders a
+plain HTML element with text content. It is defined in `rendererPrimitives` inside `codegen.config.ts`
+and appended verbatim to all generated output files.
+
+```ts
+interface AgTextNode {
+  id: string;
+  component: 'AgText';
+  text: string;                               // required
+  el?: 'p' | 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'label'; // defaults to 'span'
+  children?: string[];
+}
+```
+
+---
+
+## 2. Validation Contract
+
+### 2.1 `validate(value, options?)`
+
+Single-node entry point. Wraps `AgNodeSchema.safeParse()`.
+
+```ts
+import { validate } from '@agnosticui/schema';
+
+const result = validate(unknownValue);
+if (result.success) {
+  // result.data is a fully typed AgNode
+} else {
+  // result.errors: string[]  — "field.path: message" format, always present
+  // result.hints: string[]   — actionable developer suggestions, present in dev mode
+}
+```
+
+**Dev mode** is enabled when `options.dev` is `true`, or when `process.env.NODE_ENV !== 'production'`
+(defaulting to dev when the environment variable is absent). Dev hints include the component name,
+the offending field, and a concrete correction suggestion.
+
+### 2.2 `validateGraph(nodes, options?)`
+
+Graph-level entry point. Validates each node individually, then checks that every `children` ID
+reference resolves to another node within the same array.
+
+```ts
+import { validateGraph } from '@agnosticui/schema';
+
+const result = validateGraph(nodes);
+if (result.success) {
+  // all nodes valid, all child refs resolve
+} else {
+  // result.errors: GraphNodeError[] — one entry per failing node
+  // each GraphNodeError: { nodeId, errors: string[], hints?: string[] }
+}
+```
+
+**Child ID resolution:** if a node lists `"children": ["btn-x"]` but no node with `id: "btn-x"`
+exists in the array, `validateGraph` adds a `child ref "btn-x" not found in graph` error to that
+node's `GraphNodeError`. Single-node `validate()` does not perform this check.
+
+**Unknown `component` values:** `AgNodeSchema` is a strict discriminated union. A node with an
+unrecognized `component` string fails validation with a Zod "invalid_union_discriminator" error.
+
+---
+
+## 3. Codegen Pipeline
+
+All six output files (`schema.ts`, `types.ts`, `index.ts`, and the three renderers) are
+AUTO-GENERATED. Never edit them by hand. Run `npm run codegen` from `v2/schema/` to regenerate.
+
+### 3.1 Source of Truth
+
+The codegen reads every `v2/lib/src/components/*/core/_*.ts` file via ts-morph, extracts the
+`*Props` interface, and derives the SDUI schema from it. The `codegen.config.ts` file contains
+all design decisions that cannot be auto-detected from the source types.
+
+### 3.2 `omitConfig`
+
+Non-function props to exclude per component. Only needed for props that are runtime-stateful or
+render-internal and cannot be expressed as a static JSON value:
+
+- `AgButton`, `AgButtonFx`: `toggle`, `pressed` — toggle mode and current press state require JS tracking
+- `AgCheckbox`: `indeterminate`, `theme` — tri-state requires programmatic setting; theme is an internal CSS hook
+- `AgIconButton`, `AgIconButtonFx`: `pressed` — current toggle state
+- `AgToggle`, `AgRating`, `AgSelectionButtonGroup`, `AgSelectionCardGroup`: `validationMessages` — complex nested object; `errorMessage` covers SDUI needs
+- `AgScrollProgress`: `target` — HTMLElement reference, not JSON-serializable
+- `AgPagination`: `offset`, `navigationLabels` — complex non-scalar types
+- `AgSlider`: `value` — accepts a `number | [number, number]` tuple; not a simple JSON scalar
+
+Function-typed props are auto-detected by type inspection and do not need to be listed here.
+
+### 3.3 `actionAliasMap`
+
+Maps each function prop name from the core interface to its SDUI string alias. Props in this map
+get an optional `string` field in the generated schema (e.g. `on_click?: string`). Props not in
+this map are silently dropped; low-level browser events (`onFocus`, `onBlur`, `onInput`) are not
+SDUI-actionable and are intentionally excluded.
+
+```ts
+onClick              -> on_click
+onChange             -> on_change
+onTagRemove          -> on_remove
+onAlertDismiss       -> on_dismiss
+onDialogOpen         -> on_open   // also onDrawerOpen
+onDialogClose        -> on_close  // also onDrawerClose
+onDialogCancel       -> on_cancel // also onDrawerCancel
+onShow               -> on_show   // Popover
+onHide               -> on_hide   // Popover, Tooltip
+onSelectionChange    -> on_change // SelectionCardGroup
+```
+
+### 3.4 `rendererSlotConfig`
+
+Controls how each component renders its slot content. Components not listed default to `'none'`.
+
+| Value | Behavior | Example components |
+|---|---|---|
+| `'none'` | Self-contained; no slot content emitted | AgInput, AgToggle, AgAvatar |
+| `'label-child'` | Renders `node.label` as text content | AgButton, AgButtonFx |
+| `'children'` | Renders child nodes recursively | AgCard, AgAlert, AgFieldset, AgTabs, AgSelectionCardGroup |
+
+The renderer switches on this value at code-generation time, not at runtime — the decision is baked
+into the emitted renderer switch case for each component.
+
+### 3.5 `skipComponents`
+
+Component directory names excluded from all generated output. These require controlled runtime state
+that cannot be expressed as a static node:
+
+| Component | Reason |
+|---|---|
+| Collapsible | open/close state |
+| Combobox | complex filtering and multi-select state |
+| Menu | open state and selected-value tracking |
+| Pagination | current-page state |
+| ScrollProgress | live scroll-position tracking — purely behavioral |
+| ScrollToButton | scroll-detection behavioral component |
+| Sidebar | open and collapsed state management |
+| SidebarNav | no Props interface; pure slot composition |
+| Slider | continuous value state requires two-way binding |
+| Toast | autoDismiss and open/close lifecycle |
+| VisuallyHidden | no Props interface; pure slot wrapper |
+
+Future issues (#375 and related) track proposals for adding stateful SDUI support for a subset of
+these (Combobox, Menu, Pagination, Sidebar, Slider, Toast).
+
+### 3.6 `typeOverrides`
+
+Explicit TypeScript type and Zod expression overrides for specific component props. Used when the
+auto-detected type from the source interface is not what the SDUI schema should expose:
+
+- `AgInput.type`: `InputType` in core includes `'textarea'`; SDUI excludes it because textarea is a
+  fundamentally different HTML element and is treated as a separate SDUI concern.
+- `AgDialog.drawerPosition`: ts-morph cannot resolve the local `EdgePosition` alias, so the enum
+  members are spelled out explicitly.
+- `AgPopover.placement`, `AgTooltip.placement`: ts-morph cannot resolve the `Placement` type from
+  `@floating-ui/dom` (an external package) in CI, so the enum is spelled out.
+- `AgRating.variant`: ts-morph resolves `RatingVariant` differently across environments; locked
+  down explicitly for consistency.
+
+### 3.7 `noUndefinedProps`
+
+A narrow config for React-only rendering. Some Lit element props are `reflect: true` decorators
+used in CSS attribute selectors (`:host([size="md"])`). Passing `undefined` via `@lit/react` removes
+the attribute and breaks the CSS variable chain even when the component has constructor defaults.
+
+For these props the codegen emits a conditional spread:
+```tsx
+{...(node.size !== undefined ? { size: node.size } : {})}
+```
+instead of the normal `size={node.size}`.
+
+Affected: `AgToggle` (`size`, `variant`), `AgInput` (`value`, `size`).
+
+### 3.8 `rendererPrimitives`
+
+Hand-maintained node types that have no AgnosticUI core component counterpart. Each primitive
+includes verbatim code blocks for the schema, types, and all three renderer switch cases. The
+codegen appends them after the discovered-component output on every run.
+
+Currently registered: `AgText`.
+
+---
+
+## 4. Stateful Component Policy
+
+A component is considered "stateful" for SDUI purposes when its meaningful behavior requires
+JS-tracked mutable state that cannot be expressed in the initial node props. The test is:
+
+> Can the component render correctly given only a plain JSON object, with no subsequent imperative
+> calls, event listeners, or framework reactivity?
+
+Components that fail this test are listed in `skipComponents` and excluded from all generated output.
+Components with partial state concerns (like `AgDialog` and `AgDrawer`, which have an `open` prop)
+are included in the schema but their stateful lifecycle events (open/close/cancel) are wired as
+action aliases so the caller can respond to them.
+
+**Dialog and Drawer** are included despite having open/close state because:
+1. `open` is a static boolean that can be set in the fixture.
+2. The open/close lifecycle fires as action aliases (`on_open`, `on_close`, `on_cancel`) so the
+   caller's actions map can respond without any renderer changes.
+3. This is sufficient for SDUI's primary use case: AI-generated UI where the LLM sets initial state.
+
+---
+
+## 5. Action Dispatch Semantics
+
+### 5.1 String Alias Resolution
+
+All interactivity in SDUI is expressed as string aliases on node props (`on_click`, `on_change`,
+`on_dismiss`, etc.). These are plain strings, not function references or expressions.
+
+At render time, the renderer wires each alias to a lookup in the caller-supplied `actions` map:
+
+```ts
+// Emitted by codegen for AgButton:
+onClick={() => dispatch(node.on_click, actions)}
+
+// dispatch implementation (identical across all three renderers):
+function dispatch(alias: string | undefined, actions: Actions): void {
+  if (alias && actions[alias]) actions[alias]();
+}
+```
+
+For events that carry a payload (currently `onSelectionChange`), the renderer emits a one-argument
+lambda and passes the extracted value to the action function:
+
+```ts
+// React:
+onSelectionChange={(e) => dispatch(node.on_change, actions, (e as CustomEvent<{value:string}>).detail.value)}
+// Vue (wrappers emit detail directly, not wrapped in CustomEvent):
+onSelectionChange={(e) => dispatch(node.on_change, actions, (e as {value:string}).value)}
+```
+
+### 5.2 XSS Boundary
+
+The actions map is the only security boundary between SDUI node data and executable code. Three
+invariants hold by construction:
+
+1. Action values in nodes are `string | undefined`. There is no `eval()`, `Function()`, or dynamic
+   import in any renderer.
+2. Only keys present in the caller-supplied `actions` map are ever called. An unknown alias is
+   silently ignored (the `dispatch` function no-ops when `actions[alias]` is `undefined`).
+3. The caller controls the complete set of callable functions at mount time. A node cannot add new
+   entries to the actions map or call any function not already registered.
+
+This means an LLM-generated node can name any alias string, but it can only trigger behavior that
+the host application already chose to expose.
+
+### 5.3 Unknown Alias Behavior
+
+If a node carries `on_click: "LAUNCH_MISSILES"` but `actions` does not have a `"LAUNCH_MISSILES"`
+key, the click event fires, `dispatch` looks up the key, finds `undefined`, and returns without
+doing anything. No error is thrown; no warning is logged.
+
+---
+
+## 6. Slot / Children Model
+
+The three slot modes (`none`, `label-child`, `children`) are described in section 3.4 above.
+This section adds implementation notes.
+
+### 6.1 Root Detection
+
+The renderer identifies root nodes (nodes to render at the top level) by building a set of all IDs
+referenced as children, then treating every node whose ID is NOT in that set as a root. Roots are
+rendered in array declaration order.
+
+### 6.2 Recursive Rendering
+
+When a node has `rendererSlot: 'children'`, the renderer recursively calls itself for each child
+ID. The recursion bottoms out at leaf nodes (nodes with no `children` or with `rendererSlot: 'none'`).
+Cycles in child references are not detected at render time — they should be caught by `validateGraph`
+if needed.
+
+### 6.3 `label-child` vs `children`
+
+`label-child` is for components whose primary slot content is a short text string (the button
+label). It reads `node.label` and renders it as the default slot. If the node also has `children`
+IDs they are ignored for slot purposes (the label takes precedence).
+
+`children` is for layout and container components. The `node.label` field (if present) is passed as
+a prop, not as slot content.
+
+---
+
+## 7. Standard Schema Compliance
+
+`AgNodeSchema` is a Zod v3 discriminated union. Zod v3 implements the
+[Standard Schema](https://standardschema.dev) `v1` interface via the `~standard` property.
+
+This means `AgNodeSchema` integrates without an adapter layer with any framework or tool that
+accepts Standard Schema (e.g. TanStack Form, Conform, Valibot-compatible validators).
+
+To use `AgNodeSchema` as a Standard Schema consumer:
+
+```ts
+import { AgNodeSchema } from '@agnosticui/schema';
+
+// Standard Schema v1 interface
+const result = AgNodeSchema['~standard'].validate(unknownValue);
+if (result instanceof Promise) {
+  // async path (Zod v3 is always synchronous, so this branch is unreachable)
+}
+```
+
+Prefer the `validate()` wrapper for application code; it normalizes the output and handles dev hints.
+
+---
+
+## 8. Streaming Assumptions
+
+### 8.1 Flat Array Model
+
+The SDUI runtime uses an **array-at-a-time** model: the consumer receives a complete `AgNode[]`
+and passes it to the renderer. There is no streaming of individual nodes or incremental graph
+patching within a single render call.
+
+### 8.2 Partial Arrays in Streaming Contexts
+
+When an LLM streams a response token-by-token, the demo applications accumulate tokens and parse
+the JSON array only after the full array delimiter (the closing `]`) arrives. The renderer is not
+called with partial data.
+
+If the consumer wants to show incremental feedback before the full array is available, it should
+render a loading indicator at the application level — the renderer itself remains stateless and
+receives only complete, valid arrays.
+
+### 8.3 Rationale for Flat Array
+
+A flat array (rather than a nested tree) was chosen because:
+1. LLMs reliably emit flat lists; deeply nested JSON causes more hallucination and formatting errors.
+2. Child references by ID are trivially parseable and diff-able.
+3. The renderer builds an O(n) lookup map at mount time; there is no runtime cost to the flat structure.
+4. `validateGraph` can check referential integrity in a single pass without tree traversal.
+
+---
+
+## 9. Versioning Policy
+
+### 9.1 Current Version
+
+The SDUI schema is at **v1**. The `component` enum values (e.g. `"AgButton"`) are the public API
+surface. All field names and allowed values for each component are part of the v1 contract.
+
+### 9.2 Breaking Changes
+
+A breaking change is any modification that would cause a previously valid node to fail validation
+or render differently. Examples:
+
+- Removing a component from the registry (removing from `AgNodeSchema` discriminated union)
+- Removing or renaming a field
+- Narrowing an enum (removing an allowed value)
+- Changing a field from optional to required
+
+### 9.3 Non-Breaking Changes
+
+- Adding a new component (new discriminant in the union)
+- Adding a new optional field to an existing component
+- Widening an enum (adding an allowed value)
+- Adding a new `rendererPrimitive`
+
+### 9.4 Communication
+
+Breaking changes will be announced via:
+1. A semver major version bump of `@agnosticui/schema` (and the renderer packages)
+2. A `CHANGELOG.md` entry at the package root with a migration guide
+3. A GitHub issue tagged `breaking-change` linking the affected components
+
+Until `@agnosticui/schema` is published to npm (tracked in a future issue), the schema version is
+communicated through the git tag on the `v2/schema/` directory.


### PR DESCRIPTION
…, #414, #415)

- SPECIFICATION.md: formal AgnosticUI SDUI spec covering node model, validation contract, codegen pipeline, stateful component policy, action dispatch semantics, slot/children model, Standard Schema compliance, streaming assumptions, and versioning policy (#415)

- Dark mode + SkinSwitcher FAB: added flash-prevention inline script to all three demo index.html files, imported skin-switcher.css in each main entry point, and copied SkinSwitcher component (React/Vue/Lit) from login playbook with adjusted import paths (#414)

- Step interaction flows: added on_click action aliases (SUBMIT_FORM, SUBMIT_LOGIN, START_TRIAL, VIEW_PLANS) to all fixture button nodes, added confirmFixtures and workflowActions maps to fixtures/index.ts, and updated StreamingOutput in all three demos to build an actions map at runtime that swaps the node array to the step-2 confirmation fixture when a button is pressed (#413)

# Pull Request

## What does this change?

Brief description of the change and why it's needed.

Fixes #(issue number, if applicable)

## Checklist

- [ ] Bug fix or new feature?
- [ ] Tests passing?
- [ ] Docs updated? (if needed - see [v2/site/docs](https://github.com/AgnosticUI/agnosticui/tree/master/v2/site/docs))

---

**Note:** If you're unsure about anything or need help, just @ mention in your PR or the related issue. We're here to help!
