### PR TITLE
fix(demos): correct CSS variable names for skin and dark mode theming

### DIFF
--- a/v2/demo-lit/src/AgSduiDemo.ts
+++ b/v2/demo-lit/src/AgSduiDemo.ts
@@ -30,7 +30,7 @@ export class AgSduiDemo extends LitElement {
 
     .demo-nav-label {
       font-size: 0.9rem;
-      color: var(--ag-color-muted, #666);
+      color: var(--ag-text-muted, #666);
     }
 
     .demo-picker-section {
@@ -52,7 +52,7 @@ export class AgSduiDemo extends LitElement {
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      color: var(--ag-color-muted, #666);
+      color: var(--ag-text-muted, #666);
     }
 
   `;

--- a/v2/demo-lit/src/index.css
+++ b/v2/demo-lit/src/index.css
@@ -11,6 +11,6 @@
 body {
   margin: 0;
   padding: 0;
-  background: var(--ag-background, #fff);
-  color: var(--ag-color, #111);
+  background: var(--ag-background-primary, #fff);
+  color: var(--ag-text-primary, #111);
 }

--- a/v2/demo-vue/src/App.vue
+++ b/v2/demo-vue/src/App.vue
@@ -70,7 +70,7 @@ const handleRegenerate = () => {
 
 .demo-nav-label {
   font-size: 0.9rem;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
 }
 
 .demo-output-header {
@@ -85,7 +85,7 @@ const handleRegenerate = () => {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
 }
 
 .demo-picker-section {
@@ -101,7 +101,7 @@ const handleRegenerate = () => {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
   margin-bottom: 0.75rem;
 }
 

--- a/v2/demo-vue/src/index.css
+++ b/v2/demo-vue/src/index.css
@@ -11,6 +11,6 @@
 body {
   margin: 0;
   padding: 0;
-  background: var(--ag-background, #fff);
-  color: var(--ag-color, #111);
+  background: var(--ag-background-primary, #fff);
+  color: var(--ag-text-primary, #111);
 }

--- a/v2/demo/src/App.css
+++ b/v2/demo/src/App.css
@@ -17,7 +17,7 @@
 
 .demo-nav-label {
   font-size: 0.9rem;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
 }
 
 .demo-output-header {
@@ -32,7 +32,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
 }
 
 
@@ -49,7 +49,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--ag-color-muted, #666);
+  color: var(--ag-text-muted, #666);
   margin-bottom: 0.75rem;
 }
 

--- a/v2/demo/src/index.css
+++ b/v2/demo/src/index.css
@@ -11,6 +11,6 @@
 body {
   margin: 0;
   padding: 0;
-  background: var(--ag-background, #fff);
-  color: var(--ag-color, #111);
+  background: var(--ag-background-primary, #fff);
+  color: var(--ag-text-primary, #111);
 }


### PR DESCRIPTION
## Summary

All three SDUI demos used undefined CSS variable names for `body` background and text color, causing skins and dark mode to have no effect on page-level contrast.

| Wrong (undefined) | Correct |
|---|---|
| `--ag-background` | `--ag-background-primary` |
| `--ag-color` | `--ag-text-primary` |
| `--ag-color-muted` | `--ag-text-muted` |

Because these variables were never defined anywhere, `body` always fell back to hardcoded `#fff`/`#111` regardless of active skin or dark mode — explaining the contrast issues seen with Midnight, Neon on Black, Deep Sea, Cyberpunk, and all dark mode skins.

## Files changed
- `v2/demo/src/index.css`
- `v2/demo-vue/src/index.css`
- `v2/demo-lit/src/index.css`
- `v2/demo/src/App.css`
- `v2/demo-vue/src/App.vue`
- `v2/demo-lit/src/AgSduiDemo.ts`