### PR TITLE
fix(collapsible): vertically center indicator SVG with inline-flex

### DIFF
--- a/v2/lib/src/components/Collapsible/core/_Collapsible.ts
+++ b/v2/lib/src/components/Collapsible/core/_Collapsible.ts
@@ -100,7 +100,8 @@ export class AgCollapsible extends LitElement implements CollapsibleProps {
 
     /* Indicator wrapper - visible by default unless noIndicator is set */
     .indicator {
-      display: block;
+      display: inline-flex;
+      align-items: center;
       flex-shrink: 0;
       transition: transform var(--ag-motion-slow) ease;
     }


### PR DESCRIPTION
display:block on .indicator caused the SVG to sit on its text baseline rather than being centered within the summary row. Switching to inline-flex + align-items:center centers the SVG without collapsing the indicator height (which bare display:flex would cause).

Closes #426
