### PR TITLE
fix(netlify): fix SDUI demo deploy previews broken since v2/sdui/ migration

### DIFF
--- a/v2/demo-lit/netlify.toml
+++ b/v2/demo-lit/netlify.toml
@@ -1,2 +1,12 @@
 [build]
   base = "v2/sdui/demo-lit"
+  ignore = "[ \"$CONTEXT\" = 'production' ] && [ -n \"$CACHED_COMMIT_REF\" ] && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- v2/sdui/schema/ v2/lib/ v2/sdui/renderers/lit/ v2/sdui/demo/ v2/sdui/demo-lit/"
+  command = """
+    (cd ../../lib && npm ci --ignore-scripts && npm run build:no-sync) &&
+    (cd ../schema && npm ci && npm run build) &&
+    (cd ../demo && npm ci --ignore-scripts) &&
+    (cd ../renderers/lit && npm ci --ignore-scripts && npm run build) &&
+    npm ci --ignore-scripts &&
+    npm run build
+  """
+  publish = "dist"

--- a/v2/demo-vue/netlify.toml
+++ b/v2/demo-vue/netlify.toml
@@ -1,2 +1,12 @@
 [build]
   base = "v2/sdui/demo-vue"
+  ignore = "[ \"$CONTEXT\" = 'production' ] && [ -n \"$CACHED_COMMIT_REF\" ] && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- v2/sdui/schema/ v2/lib/ v2/sdui/renderers/vue/ v2/sdui/demo/ v2/sdui/demo-vue/"
+  command = """
+    (cd ../../lib && npm ci --ignore-scripts && npm run build:no-sync) &&
+    (cd ../schema && npm ci && npm run build) &&
+    (cd ../demo && npm ci --ignore-scripts) &&
+    (cd ../renderers/vue && npm ci --ignore-scripts && npm run build) &&
+    npm ci --ignore-scripts &&
+    npm run build
+  """
+  publish = "dist"

--- a/v2/demo/netlify.toml
+++ b/v2/demo/netlify.toml
@@ -1,2 +1,11 @@
 [build]
   base = "v2/sdui/demo"
+  ignore = "[ \"$CONTEXT\" = 'production' ] && [ -n \"$CACHED_COMMIT_REF\" ] && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- v2/sdui/schema/ v2/lib/ v2/sdui/renderers/react/ v2/sdui/demo/"
+  command = """
+    (cd ../../lib && npm ci --ignore-scripts && npm run build:no-sync) &&
+    (cd ../schema && npm ci && npm run build) &&
+    (cd ../renderers/react && npm ci --ignore-scripts && npm run build) &&
+    npm ci --ignore-scripts &&
+    npm run build
+  """
+  publish = "dist"


### PR DESCRIPTION
Fixes #442

## Problem

The Netlify UI for `agnosticui-demo-react`, `agnosticui-demo-vue`, and `agnosticui-demo-lit` still has base directories set to the pre-migration paths (`v2/demo`, `v2/demo-vue`, `v2/demo-lit`). Those directories have no tracked files in git after the SDUI migration (PR #408), so Netlify found no `netlify.toml`, fell back to defaults, and failed.

## Fix

Adds `netlify.toml` at each old path containing:
- `base` set to the new `v2/sdui/demo*` location
- The complete build command and `publish = "dist"` written relative to the new base

This ensures the builds work whether Netlify applies the `base` override before or after reading the command settings from the file.

The `v2/sdui/demo*/netlify.toml` files (already fixed in #441) remain the canonical config once the Netlify UI base directories are updated.