### PR TITLE
fix(site): update Vue imports to named exports and fix Progress path casing

### DIFF
--- a/v2/site/docs/.vitepress/theme/components/PlaybookFab.vue
+++ b/v2/site/docs/.vitepress/theme/components/PlaybookFab.vue
@@ -65,7 +65,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vitepress'
 import { VueIcon } from 'agnosticui-core/icon/vue'
-import VueButton from 'agnosticui-core/button/vue'
+import { VueButton } from 'agnosticui-core/button/vue'
 import { Palette, X } from 'lucide-vue-next'
 import PlaybookThemePanel from '../../../components/PlaybookThemePanel.vue'
 

--- a/v2/site/docs/components/PlaybookThemePanel.vue
+++ b/v2/site/docs/components/PlaybookThemePanel.vue
@@ -119,8 +119,8 @@
 import { ref, onMounted } from 'vue'
 import { SKINS, applySkin } from '@skins/skin-switcher-core.js'
 import { SKINS_CSS } from '@skins/skins-css-data.js'
-import VueButton from 'agnosticui-core/button/vue'
-import VueInput from 'agnosticui-core/input/vue'
+import { VueButton } from 'agnosticui-core/button/vue'
+import { VueInput } from 'agnosticui-core/input/vue'
 import { VueIcon } from 'agnosticui-core/icon/vue'
 import { ImagePlus, ChevronDown, Copy, Download } from 'lucide-vue-next'
 

--- a/v2/site/docs/components/combobox.md
+++ b/v2/site/docs/components/combobox.md
@@ -128,7 +128,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import VueCombobox from 'agnosticui-core/combobox/vue';
+import { VueCombobox } from 'agnosticui-core/combobox/vue';
 import type { ComboboxOption } from 'agnosticui-core/combobox';
 
 const stateOptions: ComboboxOption[] = [

--- a/v2/site/docs/components/copybutton.md
+++ b/v2/site/docs/components/copybutton.md
@@ -92,7 +92,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueCopyButton from 'agnosticui-core/copy-button/vue'
+import { VueCopyButton } from 'agnosticui-core/copy-button/vue'
 
 export default {
   components: { VueCopyButton },

--- a/v2/site/docs/components/progress.md
+++ b/v2/site/docs/components/progress.md
@@ -57,7 +57,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { VueProgress } from 'agnosticui-core/Progress/vue/VueProgress';
+import { VueProgress } from 'agnosticui-core/progress/vue';
 
 export default defineComponent({
   components: { VueProgress }
@@ -70,7 +70,7 @@ export default defineComponent({
 ::: details React
 
 ```tsx
-import { ReactProgress } from 'agnosticui-core/Progress/react/ReactProgress';
+import { ReactProgress } from 'agnosticui-core/progress/react';
 
 export default function Example() {
   return (
@@ -93,7 +93,7 @@ export default function Example() {
 
 ```html
 <script type="module">
-  import 'agnosticui-core/Progress/core/Progress';
+  import 'agnosticui-core/progress/core';
 </script>
 
 <!-- Determinate progress -->
@@ -110,7 +110,7 @@ export default function Example() {
 
 ```javascript
 import { html } from 'lit';
-import 'agnosticui-core/Progress/core/Progress';
+import 'agnosticui-core/progress/core';
 
 const template = html`
   <ag-progress .value=${50} .max=${100} .label=${"Loading..."}></ag-progress>
@@ -238,7 +238,7 @@ The Progress component uses the native HTML5 `<progress>` element with enhanced 
 
 <script setup>
 import { ref } from 'vue';
-import { VueProgress } from 'agnosticui-core/Progress/vue/VueProgress';
+import { VueProgress } from 'agnosticui-core/progress/vue';
 
 const uploadProgress = ref(0);
 const fileName = ref('document.pdf');


### PR DESCRIPTION
## Summary

- `PlaybookFab.vue` and `PlaybookThemePanel.vue`: convert `VueButton`, `VueInput` from default to named imports
- `copybutton.md`: convert `VueCopyButton` from default to named import  
- `combobox.md`: convert `VueCombobox` from default to named import
- `progress.md`: fix 5 occurrences of capitalized `Progress/` path bug:
  - `agnosticui-core/Progress/vue/VueProgress` → `agnosticui-core/progress/vue`
  - `agnosticui-core/Progress/react/ReactProgress` → `agnosticui-core/progress/react`
  - `agnosticui-core/Progress/core/Progress` → `agnosticui-core/progress/core`

## Test plan

- [ ] Docs site builds without errors (`npm run build` in `v2/site/docs/`)
- [ ] PlaybookFab and PlaybookThemePanel render correctly (VueButton, VueInput)
- [ ] copybutton and combobox demo blocks render correctly
- [ ] progress.md examples show correct import paths

Closes #438