### PR TITLE
fix(sdui): update stale path references after v2/sdui/ migration

### DIFF
--- a/v2/sdui/examples/sdui-lit/README.md
+++ b/v2/sdui/examples/sdui-lit/README.md
@@ -36,7 +36,7 @@ npm run preview   # preview build on port 5178
 
 ## Related
 
-- `v2/schema/` — the `@agnosticui/schema` package (validation + types)
-- `v2/renderers/lit/` — the renderer this app exercises
+- `v2/sdui/schema/` — the `@agnosticui/schema` package (validation + types)
+- `v2/sdui/renderers/lit/` — the renderer this app exercises
 - `../sdui-react/`, `../sdui-vue/` — same payload, different renderers
 - Issue #351 — AgnosticUI Agent-Ready SDUI framework PRD

--- a/v2/sdui/examples/sdui-react/README.md
+++ b/v2/sdui/examples/sdui-react/README.md
@@ -39,7 +39,7 @@ npm run preview   # preview build on port 5176
 
 ## Related
 
-- `v2/schema/` — the `@agnosticui/schema` package (validation + types)
-- `v2/renderers/react/` — the renderer this app exercises
+- `v2/sdui/schema/` — the `@agnosticui/schema` package (validation + types)
+- `v2/sdui/renderers/react/` — the renderer this app exercises
 - `../sdui-vue/`, `../sdui-lit/` — same payload, different renderers
 - Issue #351 — AgnosticUI Agent-Ready SDUI framework PRD

--- a/v2/sdui/examples/sdui-vue/README.md
+++ b/v2/sdui/examples/sdui-vue/README.md
@@ -39,7 +39,7 @@ npm run preview   # preview build on port 5177
 
 ## Related
 
-- `v2/schema/` — the `@agnosticui/schema` package (validation + types)
-- `v2/renderers/react/` — the renderer this app exercises
+- `v2/sdui/schema/` — the `@agnosticui/schema` package (validation + types)
+- `v2/sdui/renderers/vue/` — the renderer this app exercises
 - `../sdui-vue/`, `../sdui-lit/` — same payload, different renderers
 - Issue #351 — AgnosticUI Agent-Ready SDUI framework PRD

--- a/v2/sdui/schema/SPECIFICATION.md
+++ b/v2/sdui/schema/SPECIFICATION.md
@@ -5,9 +5,9 @@ It covers the node model, validation pipeline, codegen contract, action dispatch
 streaming assumptions.
 
 Related files:
-- `v2/schema/README.md` — developer quick-start
-- `v2/schema/SYSTEM_PROMPT.md` — terse LLM tool definition
-- `v2/schema/scripts/codegen.config.ts` — annotated source of design decisions
+- `v2/sdui/schema/README.md` — developer quick-start
+- `v2/sdui/schema/SYSTEM_PROMPT.md` — terse LLM tool definition
+- `v2/sdui/schema/scripts/codegen.config.ts` — annotated source of design decisions
 
 ---
 
@@ -127,7 +127,7 @@ unrecognized `component` string fails validation with a Zod "invalid_union_discr
 ## 3. Codegen Pipeline
 
 All six output files (`schema.ts`, `types.ts`, `index.ts`, and the three renderers) are
-AUTO-GENERATED. Never edit them by hand. Run `npm run codegen` from `v2/schema/` to regenerate.
+AUTO-GENERATED. Never edit them by hand. Run `npm run codegen` from `v2/sdui/schema/` to regenerate.
 
 ### 3.1 Source of Truth
 
@@ -429,7 +429,7 @@ Breaking changes will be announced via:
 3. A GitHub issue tagged `breaking-change` linking the affected components
 
 Until `@agnosticui/schema` is published to npm (tracked in a future issue), the schema version is
-communicated through the git tag on the `v2/schema/` directory.
+communicated through the git tag on the `v2/sdui/schema/` directory.
 
 ## 10. Form Validation
 

--- a/v2/site/docs/docs/sdui.md
+++ b/v2/site/docs/docs/sdui.md
@@ -227,7 +227,7 @@ if (!result.success) {
 
 ## Further reading
 
-- [`v2/schema/SPECIFICATION.md`](https://github.com/AgnosticUI/agnosticui/blob/master/v2/schema/SPECIFICATION.md) — full technical specification covering the node model, codegen pipeline, action semantics, slot model, streaming, and versioning policy
-- [`v2/schema/SYSTEM_PROMPT.md`](https://github.com/AgnosticUI/agnosticui/blob/master/v2/schema/SYSTEM_PROMPT.md) — condensed reference for LLM consumers generating node arrays
+- [`v2/sdui/schema/SPECIFICATION.md`](https://github.com/AgnosticUI/agnosticui/blob/master/v2/sdui/schema/SPECIFICATION.md) — full technical specification covering the node model, codegen pipeline, action semantics, slot model, streaming, and versioning policy
+- [`v2/sdui/schema/SYSTEM_PROMPT.md`](https://github.com/AgnosticUI/agnosticui/blob/master/v2/sdui/schema/SYSTEM_PROMPT.md) — condensed reference for LLM consumers generating node arrays
 - [Form Association (FACE)](/docs/form-association) — how AgnosticUI form components work without a `<form>` wrapper
 - [GitHub: AgnosticUI/agnosticui](https://github.com/AgnosticUI/agnosticui) — source for all three renderer packages and demo apps


### PR DESCRIPTION
## Summary

After the `v2/sdui/` directory consolidation (PR #408), several markdown docs still referenced the old pre-migration paths. This PR updates them:

| File | Old path | New path |
|------|----------|----------|
| `SPECIFICATION.md` (5x) | `v2/schema/` | `v2/sdui/schema/` |
| `sdui-lit/README.md` | `v2/schema/`, `v2/renderers/lit/` | `v2/sdui/schema/`, `v2/sdui/renderers/lit/` |
| `sdui-react/README.md` | `v2/schema/`, `v2/renderers/react/` | `v2/sdui/schema/`, `v2/sdui/renderers/react/` |
| `sdui-vue/README.md` | `v2/schema/`, `v2/renderers/react/` | `v2/sdui/schema/`, `v2/sdui/renderers/vue/` |
| `site/docs/sdui.md` | GitHub blob links to `v2/schema/` | Updated to `v2/sdui/schema/` |

## Verified clean (no changes needed)
- All `package.json` `file:` dependencies resolve correctly from new locations
- Vue renderer already uses named imports for all `VueX` components
- React renderer already uses named imports for all `ReactX` components

## Test plan

- [ ] Links in `SPECIFICATION.md` point to existing paths
- [ ] Links in `site/docs/sdui.md` resolve on GitHub

Closes #439