### PR TITLE
fix(site): update all Vue example imports to named exports

### DIFF
--- a/v2/site/docs/components/alert.md
+++ b/v2/site/docs/components/alert.md
@@ -132,7 +132,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 <script>
 import { Info } from "lucide-vue-next";
-import VueAlert from "agnosticui-core/alert/vue";
+import { VueAlert } from "agnosticui-core/alert/vue";
 export default {
   name: "AlertExamples",
   components: { VueAlert, Info },
@@ -358,7 +358,7 @@ Alerts can be made dismissible by adding the `dismissible` prop. This displays a
 </template>
 
 <script>
-import VueAlert from "agnosticui-core/alert/vue";
+import { VueAlert } from "agnosticui-core/alert/vue";
 
 export default {
   components: { VueAlert },

--- a/v2/site/docs/components/badge.md
+++ b/v2/site/docs/components/badge.md
@@ -93,7 +93,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 
 <script>
 import { VueBadge } from "agnosticui-core/badge/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { VueIcon } from "agnosticui-core/icon/vue";
 
 export default {

--- a/v2/site/docs/components/breadcrumb.md
+++ b/v2/site/docs/components/breadcrumb.md
@@ -84,7 +84,7 @@ The CLI copies source code directly into your project, giving you full visibilit
   </section>
 </template>
 <script>
-import VueBreadcrumb from "agnosticui-core/breadcrumb/vue";
+import { VueBreadcrumb } from "agnosticui-core/breadcrumb/vue";
 export default {
   name: "BreadcrumbExamples",
   components: { VueBreadcrumb },

--- a/v2/site/docs/components/button.md
+++ b/v2/site/docs/components/button.md
@@ -78,7 +78,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   name: "ButtonExample",

--- a/v2/site/docs/components/dialog.md
+++ b/v2/site/docs/components/dialog.md
@@ -101,7 +101,7 @@ import VueDialog, {
   VueDialogHeader,
   VueDialogFooter,
 } from "agnosticui-core/dialog/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   components: {

--- a/v2/site/docs/components/drawer.md
+++ b/v2/site/docs/components/drawer.md
@@ -123,8 +123,8 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueDrawer from "agnosticui-core/drawer/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueDrawer } from "agnosticui-core/drawer/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   components: {

--- a/v2/site/docs/components/empty-state.md
+++ b/v2/site/docs/components/empty-state.md
@@ -121,8 +121,8 @@ The CLI copies source code directly into your project, giving you full visibilit
 
 <script>
 import { VueEmptyState } from "agnosticui-core/empty-state/vue";
-import VueIcon from "agnosticui-core/icon/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueIcon } from "agnosticui-core/icon/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   components: {

--- a/v2/site/docs/components/fieldset.md
+++ b/v2/site/docs/components/fieldset.md
@@ -140,10 +140,10 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueFieldset from "agnosticui-core/fieldset/vue";
-import VueInput from "agnosticui-core/input/vue";
-import VueRadio from "agnosticui-core/radio/vue";
-import VueCheckbox from "agnosticui-core/checkbox/vue";
+import { VueFieldset } from "agnosticui-core/fieldset/vue";
+import { VueInput } from "agnosticui-core/input/vue";
+import { VueRadio } from "agnosticui-core/radio/vue";
+import { VueCheckbox } from "agnosticui-core/checkbox/vue";
 
 export default {
   components: {

--- a/v2/site/docs/components/icon-button.md
+++ b/v2/site/docs/components/icon-button.md
@@ -120,7 +120,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueIconButton from "agnosticui-core/icon-button/vue";
+import { VueIconButton } from "agnosticui-core/icon-button/vue";
 import { Settings, Trash, Save, Heart, Loader, Zap } from "lucide-vue-next";
 
 export default {

--- a/v2/site/docs/components/input.md
+++ b/v2/site/docs/components/input.md
@@ -101,7 +101,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueInput from "agnosticui-core/input/vue";
+import { VueInput } from "agnosticui-core/input/vue";
 import { DollarSign } from "lucide-vue-next";
 
 export default {
@@ -558,7 +558,7 @@ Add icons or text before or after the input using slots. Addons are **automatica
 </template>
 
 <script>
-import VueInput from "agnosticui-core/input/vue";
+import { VueInput } from "agnosticui-core/input/vue";
 import { Globe, DollarSign } from "lucide-vue-next";
 
 export default {

--- a/v2/site/docs/components/popover.md
+++ b/v2/site/docs/components/popover.md
@@ -103,7 +103,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 
 <script>
 import { VuePopover } from "agnosticui-core/popover/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   components: {

--- a/v2/site/docs/components/sidebar.md
+++ b/v2/site/docs/components/sidebar.md
@@ -153,7 +153,7 @@ The CLI copies source code directly into your project, giving you full visibilit
 </template>
 
 <script>
-import VueSidebar from "agnosticui-core/sidebar/vue";
+import { VueSidebar } from "agnosticui-core/sidebar/vue";
 import {
   VueSidebarNav,
   VueSidebarNavItem,

--- a/v2/site/docs/examples/AlertExamples.vue
+++ b/v2/site/docs/examples/AlertExamples.vue
@@ -298,7 +298,7 @@
 </template>
 <script>
 import { Info } from "lucide-vue-next";
-import VueAlert from "agnosticui-core/alert/vue";
+import { VueAlert } from "agnosticui-core/alert/vue";
 export default {
   name: "AlertExamples",
   components: { VueAlert, Info },

--- a/v2/site/docs/examples/BadgeExamples.vue
+++ b/v2/site/docs/examples/BadgeExamples.vue
@@ -396,10 +396,10 @@
 
 <script>
 import { VueBadge } from "agnosticui-core/badge/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { VueIcon } from "agnosticui-core/icon/vue";
 import { Mail, Bell, Info, ShoppingCart } from "lucide-vue-next";
-import VueAlert from "agnosticui-core/alert/vue";
+import { VueAlert } from "agnosticui-core/alert/vue";
 import { VueVisuallyHidden } from "agnosticui-core/visually-hidden/vue";
 
 export default {

--- a/v2/site/docs/examples/BreadcrumbExamples.vue
+++ b/v2/site/docs/examples/BreadcrumbExamples.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script>
-import VueBreadcrumb from "agnosticui-core/breadcrumb/vue";
+import { VueBreadcrumb } from "agnosticui-core/breadcrumb/vue";
 export default {
   name: "BreadcrumbExamples",
   components: { VueBreadcrumb },

--- a/v2/site/docs/examples/ButtonExamples.vue
+++ b/v2/site/docs/examples/ButtonExamples.vue
@@ -1131,7 +1131,7 @@
   </section>
 </template>
 <script>
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { VueVisuallyHidden } from "agnosticui-core/visually-hidden/vue";
 import { VueIcon } from "agnosticui-core/icon/vue";
 

--- a/v2/site/docs/examples/CardExamples.vue
+++ b/v2/site/docs/examples/CardExamples.vue
@@ -310,7 +310,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import { VueCard } from "agnosticui-core/card/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default defineComponent({
   name: "CardExamples",

--- a/v2/site/docs/examples/ComboboxExamples.vue
+++ b/v2/site/docs/examples/ComboboxExamples.vue
@@ -435,7 +435,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import VueCombobox from "agnosticui-core/combobox/vue";
+import { VueCombobox } from "agnosticui-core/combobox/vue";
 import type { ComboboxOption } from "agnosticui-core/combobox";
 
 // State options

--- a/v2/site/docs/examples/DialogExamples.vue
+++ b/v2/site/docs/examples/DialogExamples.vue
@@ -142,7 +142,7 @@ import VueDialog, {
   VueDialogHeader,
   VueDialogFooter,
 } from "agnosticui-core/dialog/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   name: "DialogExamples",

--- a/v2/site/docs/examples/DrawerExamples.vue
+++ b/v2/site/docs/examples/DrawerExamples.vue
@@ -237,8 +237,8 @@
 </template>
 
 <script>
-import VueDrawer from "agnosticui-core/drawer/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueDrawer } from "agnosticui-core/drawer/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { Plus, Upload, Download, Share2, Filter } from "lucide-vue-next";
 
 export default {

--- a/v2/site/docs/examples/EmptyStateExamples.vue
+++ b/v2/site/docs/examples/EmptyStateExamples.vue
@@ -632,7 +632,7 @@
 
 <script>
 import { VueEmptyState } from "agnosticui-core/empty-state/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import {
   SearchX,
   Folder,

--- a/v2/site/docs/examples/FieldsetExamples.vue
+++ b/v2/site/docs/examples/FieldsetExamples.vue
@@ -689,10 +689,10 @@
 
 <script>
 import { VueFieldset } from "agnosticui-core/fieldset/vue";
-import VueInput from "agnosticui-core/input/vue";
+import { VueInput } from "agnosticui-core/input/vue";
 import { VueRadio } from "agnosticui-core/radio/vue";
 import { VueCheckbox } from "agnosticui-core/checkbox/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import {
   Search,
   CreditCard,

--- a/v2/site/docs/examples/IconButtonExamples.vue
+++ b/v2/site/docs/examples/IconButtonExamples.vue
@@ -261,7 +261,7 @@
 </template>
 
 <script>
-import VueIconButton from "agnosticui-core/icon-button/vue";
+import { VueIconButton } from "agnosticui-core/icon-button/vue";
 import { VueIcon } from "agnosticui-core/icon/vue";
 import {
   Settings,

--- a/v2/site/docs/examples/ImageExamples.vue
+++ b/v2/site/docs/examples/ImageExamples.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import VueImage from "agnosticui-core/image/vue";
+import { VueImage } from "agnosticui-core/image/vue";
 import { VueIcon } from "agnosticui-core/icon/vue";
 import { TriangleAlert } from "lucide-vue-next";
 

--- a/v2/site/docs/examples/InputExamples.vue
+++ b/v2/site/docs/examples/InputExamples.vue
@@ -477,7 +477,7 @@
 </template>
 
 <script>
-import VueInput from "agnosticui-core/input/vue";
+import { VueInput } from "agnosticui-core/input/vue";
 import { Globe, DollarSign, Percent, Search, User2 } from "lucide-vue-next";
 
 export default {

--- a/v2/site/docs/examples/MessageBubbleExamples.vue
+++ b/v2/site/docs/examples/MessageBubbleExamples.vue
@@ -356,8 +356,8 @@
 import { defineComponent } from "vue";
 import { VueMessageBubble } from "agnosticui-core/message-bubble/vue";
 import { VueAvatar } from "agnosticui-core/avatar/vue";
-import VueInput from "agnosticui-core/input/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueInput } from "agnosticui-core/input/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { MessageCircle, Send, Bot, Trash2 } from "lucide-vue-next";
 
 export default defineComponent({

--- a/v2/site/docs/examples/PopoverExamples.vue
+++ b/v2/site/docs/examples/PopoverExamples.vue
@@ -350,7 +350,7 @@
 
 <script>
 import { VuePopover } from "agnosticui-core/popover/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { Menu, MoreVertical } from "lucide-vue-next";
 import { ref } from "vue";
 

--- a/v2/site/docs/examples/ProgressRingExamples.vue
+++ b/v2/site/docs/examples/ProgressRingExamples.vue
@@ -189,7 +189,7 @@
 <script lang="ts">
 import { defineComponent, ref, onUnmounted } from "vue";
 import { VueProgressRing } from "agnosticui-core/progress-ring/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default defineComponent({
   name: "ProgressRingExamples",

--- a/v2/site/docs/examples/SidebarExamples.vue
+++ b/v2/site/docs/examples/SidebarExamples.vue
@@ -740,7 +740,7 @@
 </template>
 
 <script>
-import VueSidebar from "agnosticui-core/sidebar/vue";
+import { VueSidebar } from "agnosticui-core/sidebar/vue";
 import {
   VueSidebarNav,
   VueSidebarNavItem,

--- a/v2/site/docs/examples/TimelineExamples.vue
+++ b/v2/site/docs/examples/TimelineExamples.vue
@@ -640,7 +640,7 @@ import {
 } from "agnosticui-core/timeline/vue";
 import { VueIcon as AgIcon } from "agnosticui-core/icon/vue";
 import { VueCard as AgCard } from "agnosticui-core/card/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { VueBadge as AgBadge } from "agnosticui-core/badge/vue";
 import { VueIconButton as AgIconButton } from "agnosticui-core/icon-button/vue";
 

--- a/v2/site/docs/examples/ToggleExamples.vue
+++ b/v2/site/docs/examples/ToggleExamples.vue
@@ -224,8 +224,8 @@
 </template>
 
 <script>
-import VueToggle from "agnosticui-core/toggle/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueToggle } from "agnosticui-core/toggle/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default {
   name: "ToggleExamples",

--- a/v2/site/docs/examples/TooltipExamples.vue
+++ b/v2/site/docs/examples/TooltipExamples.vue
@@ -135,8 +135,8 @@
 </template>
 
 <script>
-import VueTooltip from "agnosticui-core/tooltip/vue";
-import VueButton from "agnosticui-core/button/vue";
+import { VueTooltip } from "agnosticui-core/tooltip/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 import { Pencil, Trash2, Download, Share2 } from "lucide-vue-next";
 
 export default {


### PR DESCRIPTION
## Summary

The installed `agnosticui-core@2.0.0-alpha.24` only exports named exports from `*/vue` subpaths (e.g. `export { VueButton }`). All 32 files that were using default imports were causing component pages to break with undefined components.

## Files fixed

**20 example `.vue` files** (`v2/site/docs/examples/`):
AlertExamples, BadgeExamples, BreadcrumbExamples, ButtonExamples, CardExamples, ComboboxExamples, DialogExamples, DrawerExamples, EmptyStateExamples, FieldsetExamples, IconButtonExamples, ImageExamples, InputExamples, MessageBubbleExamples, PopoverExamples, ProgressRingExamples, SidebarExamples, TimelineExamples, ToggleExamples, TooltipExamples

**12 component `.md` live-demo blocks** (`v2/site/docs/components/`):
alert, badge, breadcrumb, button, dialog, drawer, empty-state, fieldset, icon-button, input, popover, sidebar

## Change pattern

```ts
// BEFORE
import VueButton from "agnosticui-core/button/vue";

// AFTER
import { VueButton } from "agnosticui-core/button/vue";
```

## Test plan

- [ ] Component pages render live demos correctly in `npm run docs:dev`
- [ ] No VitePress build errors (`npm run docs:build`)