### PR TITLE
Fix #432: add files field, tighten peer dep floor, add READMEs to renderer packages

### DIFF
--- a/v2/sdui/renderers/lit/README.md
+++ b/v2/sdui/renderers/lit/README.md
@@ -1,0 +1,41 @@
+# @agnosticui/render-lit
+
+Lit/web-component renderer for [AgnosticUI](https://agnosticui.com) schema-driven UI (SDUI) nodes.
+
+## Install
+
+```bash
+npm install @agnosticui/render-lit @agnosticui/schema agnosticui-core
+```
+
+## Peer dependencies
+
+| Package | Version |
+|---------|---------|
+| `agnosticui-core` | `>=2.0.0-alpha.25` |
+| `lit` | `^3.0.0` |
+
+## Usage
+
+```ts
+import '@agnosticui/render-lit';
+import type { AgNode } from '@agnosticui/schema';
+
+const el = document.createElement('ag-dynamic-renderer');
+
+el.nodes = [
+  { id: 'btn-1', component: 'AgButton', label: 'Click me', on_click: 'SUBMIT' },
+] satisfies AgNode[];
+
+el.actions = {
+  SUBMIT: () => console.log('submitted'),
+};
+
+document.body.appendChild(el);
+```
+
+## How it works
+
+Registers an `<ag-dynamic-renderer>` custom element that accepts a `nodes` array of `AgNode` objects and an `actions` map. It renders into light DOM so child elements are accessible to parent frameworks.
+
+Nodes reference each other by `id` via the `children` array; nodes not referenced as children are treated as roots. Actions are dispatched through the string-alias map — unknown aliases are silently ignored, providing an XSS boundary.

--- a/v2/sdui/renderers/lit/package.json
+++ b/v2/sdui/renderers/lit/package.json
@@ -18,8 +18,12 @@
   "dependencies": {
     "@agnosticui/schema": "file:../../schema"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "peerDependencies": {
-    "agnosticui-core": ">=2.0.0-alpha",
+    "agnosticui-core": ">=2.0.0-alpha.25",
     "lit": "^3.0.0"
   },
   "devDependencies": {

--- a/v2/sdui/renderers/react/README.md
+++ b/v2/sdui/renderers/react/README.md
@@ -1,0 +1,42 @@
+# @agnosticui/render-react
+
+React renderer for [AgnosticUI](https://agnosticui.com) schema-driven UI (SDUI) nodes.
+
+## Install
+
+```bash
+npm install @agnosticui/render-react @agnosticui/schema agnosticui-core
+```
+
+## Peer dependencies
+
+| Package | Version |
+|---------|---------|
+| `agnosticui-core` | `>=2.0.0-alpha.25` |
+| `react` | `>=18` |
+| `react-dom` | `>=18` |
+
+## Usage
+
+```tsx
+import { AgDynamicRenderer } from '@agnosticui/render-react';
+import type { AgNode } from '@agnosticui/schema';
+
+const nodes: AgNode[] = [
+  { id: 'btn-1', component: 'AgButton', label: 'Click me', on_click: 'SUBMIT' },
+];
+
+const actions = {
+  SUBMIT: () => console.log('submitted'),
+};
+
+export function App() {
+  return <AgDynamicRenderer nodes={nodes} actions={actions} />;
+}
+```
+
+## How it works
+
+`AgDynamicRenderer` takes a flat array of `AgNode` objects and renders the corresponding AgnosticUI React components. Nodes reference each other by `id` via the `children` array; nodes not referenced as children are treated as roots.
+
+Actions are dispatched through a string-alias map (`actions` prop) — unknown aliases are silently ignored, providing an XSS boundary.

--- a/v2/sdui/renderers/react/package.json
+++ b/v2/sdui/renderers/react/package.json
@@ -18,8 +18,12 @@
   "dependencies": {
     "@agnosticui/schema": "file:../../schema"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "peerDependencies": {
-    "agnosticui-core": ">=2.0.0-alpha",
+    "agnosticui-core": ">=2.0.0-alpha.25",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/v2/sdui/renderers/vue/README.md
+++ b/v2/sdui/renderers/vue/README.md
@@ -1,0 +1,43 @@
+# @agnosticui/render-vue
+
+Vue renderer for [AgnosticUI](https://agnosticui.com) schema-driven UI (SDUI) nodes.
+
+## Install
+
+```bash
+npm install @agnosticui/render-vue @agnosticui/schema agnosticui-core
+```
+
+## Peer dependencies
+
+| Package | Version |
+|---------|---------|
+| `agnosticui-core` | `>=2.0.0-alpha.25` |
+| `vue` | `>=3` |
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { AgDynamicRenderer } from '@agnosticui/render-vue';
+import type { AgNode } from '@agnosticui/schema';
+
+const nodes: AgNode[] = [
+  { id: 'btn-1', component: 'AgButton', label: 'Click me', on_click: 'SUBMIT' },
+];
+
+const actions = {
+  SUBMIT: () => console.log('submitted'),
+};
+</script>
+
+<template>
+  <AgDynamicRenderer :nodes="nodes" :actions="actions" />
+</template>
+```
+
+## How it works
+
+`AgDynamicRenderer` takes a flat array of `AgNode` objects and renders the corresponding AgnosticUI Vue components. Nodes reference each other by `id` via the `children` array; nodes not referenced as children are treated as roots.
+
+Actions are dispatched through a string-alias map (`:actions` prop) — unknown aliases are silently ignored, providing an XSS boundary.

--- a/v2/sdui/renderers/vue/package.json
+++ b/v2/sdui/renderers/vue/package.json
@@ -18,8 +18,12 @@
   "dependencies": {
     "@agnosticui/schema": "file:../../schema"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "peerDependencies": {
-    "agnosticui-core": ">=2.0.0-alpha",
+    "agnosticui-core": ">=2.0.0-alpha.25",
     "vue": ">=3"
   },
   "devDependencies": {


### PR DESCRIPTION
- files: ["dist", "README.md"] prevents src/test/config files from being published
- agnosticui-core peer dep floor bumped to >=2.0.0-alpha.25 (first version with
  all Props interfaces for SDUI codegen eligibility, from PR #453)
- Add README to each renderer with install, peer deps, and usage example
