### PR TITLE
Fix #432: replace file: schema dep with npm version in all 3 renderers

### DIFF
--- a/v2/sdui/renderers/lit/package.json
+++ b/v2/sdui/renderers/lit/package.json
@@ -16,7 +16,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@agnosticui/schema": "file:../../schema"
+    "@agnosticui/schema": "^2.0.0-alpha.1"
   },
   "files": [
     "dist",

--- a/v2/sdui/renderers/react/package.json
+++ b/v2/sdui/renderers/react/package.json
@@ -16,7 +16,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@agnosticui/schema": "file:../../schema"
+    "@agnosticui/schema": "^2.0.0-alpha.1"
   },
   "files": [
     "dist",

--- a/v2/sdui/renderers/vue/package.json
+++ b/v2/sdui/renderers/vue/package.json
@@ -16,7 +16,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@agnosticui/schema": "file:../../schema"
+    "@agnosticui/schema": "^2.0.0-alpha.1"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Replaces the local monorepo file:../../schema reference with the published npm version ^2.0.0-alpha.1 so npm consumers can resolve @agnosticui/schema after the packages are published.