### PR TITLE
Fix #469: wrap --ag-focus in rgba() to restore invisible focus rings

### DIFF
--- a/v2/lib/src/components/Badge/core/_Badge.ts
+++ b/v2/lib/src/components/Badge/core/_Badge.ts
@@ -108,7 +108,7 @@ export class AgBadge extends LitElement implements BadgeProps {
       filter: brightness(1.1);
     }
     :host([interactive]) .badge:focus-visible {
-      outline: var(--ag-focus-width) solid var(--ag-focus);
+      outline: var(--ag-focus-width) solid rgba(var(--ag-focus), 0.5);
       outline-offset: var(--ag-focus-offset);
     }
     :host([single-char]) .badge {

--- a/v2/lib/src/components/Breadcrumb/core/_Breadcrumb.ts
+++ b/v2/lib/src/components/Breadcrumb/core/_Breadcrumb.ts
@@ -145,7 +145,7 @@ export class AgBreadcrumb extends LitElement implements BreadcrumbProps {
     }
 
     .ag-breadcrumb__link:focus-visible {
-      outline: var(--ag-focus-width) solid var(--ag-focus);
+      outline: var(--ag-focus-width) solid rgba(var(--ag-focus), 0.5);
       outline-offset: var(--ag-focus-offset);
     }
 

--- a/v2/lib/src/components/Collapsible/core/_Collapsible.ts
+++ b/v2/lib/src/components/Collapsible/core/_Collapsible.ts
@@ -88,7 +88,7 @@ export class AgCollapsible extends LitElement implements CollapsibleProps {
     }
 
     summary:focus-visible {
-      outline: var(--ag-focus-width) solid var(--ag-focus);
+      outline: var(--ag-focus-width) solid rgba(var(--ag-focus), 0.5);
       outline-offset: var(--ag-focus-offset);
       transition: outline var(--ag-motion-medium) ease;
     }

--- a/v2/lib/src/components/IconButton/core/_IconButton.ts
+++ b/v2/lib/src/components/IconButton/core/_IconButton.ts
@@ -152,7 +152,7 @@ export class AgIconButton extends LitElement implements IconButtonProps {
 
     /* Focus state - High contrast, color-independent */
     button:focus-visible {
-      outline: var(--ag-focus-width) solid var(--ag-focus);
+      outline: var(--ag-focus-width) solid rgba(var(--ag-focus), 0.5);
       outline-offset: var(--ag-focus-offset);
     }
 

--- a/v2/lib/src/components/Menu/core/_Menu.ts
+++ b/v2/lib/src/components/Menu/core/_Menu.ts
@@ -834,7 +834,7 @@ export class AgMenuItem extends LitElement implements MenuItemProps {
     button:focus,
     a:focus {
       background-color: var(--ag-background-secondary);
-      outline: var(--ag-focus-width) solid var(--ag-focus);
+      outline: var(--ag-focus-width) solid rgba(var(--ag-focus), 0.5);
       outline-offset: 0;
     }
 

--- a/v2/site/package-lock.json
+++ b/v2/site/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stackblitz/sdk": "^1.11.0",
-        "agnosticui-core": "file:../lib/agnosticui-core-2.0.0-alpha.26.tgz",
+        "agnosticui-core": "file:../lib/agnosticui-core-2.0.0-alpha.27.tgz",
         "lucide-vue-next": "^0.545.0",
         "markdown-it-table": "^4.1.1",
         "shiki": "^3.20.0"
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/agnosticui-core": {
-      "version": "2.0.0-alpha.26",
-      "resolved": "file:../lib/agnosticui-core-2.0.0-alpha.26.tgz",
-      "integrity": "sha512-RsYmjpFpbJXReKYFBafRgFEcC0u9qaJA2j27+pGKQXASSk+1Tx1nOGGgOe10PLiG9bLWU6CZa4wfzkjVt0+3iA==",
+      "version": "2.0.0-alpha.27",
+      "resolved": "file:../lib/agnosticui-core-2.0.0-alpha.27.tgz",
+      "integrity": "sha512-GE5XtZeAoKREa4aLxZbG4ALn2dt29C7RQSHXo12qckfUdNsM25epeVSMfn/A7DgWWbkR69A4r2GBwOCiHVb9bg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",


### PR DESCRIPTION
## Summary

- `--ag-focus` is a raw RGB triplet token (e.g. `210, 105, 30`), so using it bare as `solid var(--ag-focus)` produces an invalid CSS color and an invisible focus ring
- Fixed 5 components by wrapping with `rgba(var(--ag-focus), 0.5)`, matching the correct pattern already used by Accordion, Button, Checkbox, Input, Link, etc.

Components fixed:
- `Collapsible` — `summary:focus-visible` (primary issue)
- `Badge` — interactive badge `:focus-visible`
- `Breadcrumb` — link `:focus-visible`
- `Menu` — button/a `:focus`
- `IconButton` — button `:focus-visible`

## Test plan

- [x] Verified focus ring visible on `ag-collapsible` in `v2/sdui/demo-lit` via keyboard Tab navigation
- [x] Fix is in Lit shadow DOM `static styles`, so React and Vue wrappers inherit it automatically

Closes #469