### PR TITLE
Fix #477: Author sdui.json agentic intent decoration for all 8 playbooks

### DIFF
--- a/v2/playbooks-manifest.json
+++ b/v2/playbooks-manifest.json
@@ -203,7 +203,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "login-v2": {
       "title": "Login Variant II",
@@ -426,7 +429,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "onboarding": {
       "title": "Onboarding",
@@ -632,7 +638,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "onboarding-v2": {
       "title": "Onboarding Carousel Wizard V2",
@@ -824,7 +833,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "dashboard": {
       "title": "Dashboard",
@@ -1407,7 +1419,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "support": {
       "title": "Support Center",
@@ -1732,7 +1747,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "grid": {
       "title": "Data Grid",
@@ -2061,7 +2079,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "grid-v2": {
       "title": "Data Grid V2",
@@ -2398,7 +2419,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "blog": {
       "title": "Blog / Article Reader",
@@ -2705,7 +2729,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "landing": {
       "title": "Landing / Marketing Page",
@@ -2970,7 +2997,10 @@
       },
       "contentReplacements": {
         "../../../../skins/skin-switcher-core.js": "./skins/skin-switcher-core.js"
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     },
     "form-association": {
       "title": "Contact Form (FACE)",
@@ -3206,7 +3236,10 @@
             "tsconfig.json"
           ]
         }
-      }
+      },
+      "rootFiles": [
+        "sdui.json"
+      ]
     }
   }
 }

--- a/v2/playbooks/blog/sdui.json
+++ b/v2/playbooks/blog/sdui.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "blog",
+  "displayName": "Blog / Article Reader",
+  "description": "Single-column editorial reading experience with scroll-progress tracking, rich article body, tagged categories, and a related-articles section.",
+  "intent": {
+    "triggers": ["blog", "articles", "content listing", "post detail", "editorial", "article reader", "reading experience"],
+    "summary": "When the user asks for a blog, article reader, or content-listing page, refer to the AgnosticUI Blog / Article Reader Playbook."
+  },
+  "recipe": {
+    "layout": "Single-column centered layout. AgScrollProgress bar pinned to the top edge. Article header: title, author AgAvatar, date, AgTag list. Full-width hero image in AgAspectRatio. Body copy with AgMark highlights. AgDivider between sections. Related articles AgTabs below the body. AgScrollToButton fixed in the bottom-right corner.",
+    "components": [
+      { "component": "AgScrollProgress", "role": "Thin progress bar at the top edge tracking read depth" },
+      { "component": "AgAvatar",         "role": "Author photo in the article byline" },
+      { "component": "AgTag",            "role": "Category and topic labels below the article title" },
+      { "component": "AgAspectRatio",    "role": "Constrains the hero image to a fixed ratio at any width" },
+      { "component": "AgMark",           "role": "Highlighted pull-quotes or keyword emphasis in body text" },
+      { "component": "AgTabs",           "role": "Switches between Related Articles, Comments, and Newsletter sections" },
+      { "component": "AgScrollToButton", "role": "Floating button that scrolls back to the top after reading" },
+      { "component": "AgBadge",          "role": "Estimated read-time badge displayed beside the article title" }
+    ],
+    "notes": "The hero image sits inside AgAspectRatio so it never reflows on resize. Example:\n```json\n{ \"id\": \"hero\", \"component\": \"AgAspectRatio\", \"props\": { \"ratio\": \"16/9\" }, \"children\": [\"hero-img\"] }\n```"
+  }
+}

--- a/v2/playbooks/dashboard/sdui.json
+++ b/v2/playbooks/dashboard/sdui.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "dashboard",
+  "displayName": "Discovery Dashboard",
+  "description": "Layout orchestration for data-heavy views with metric KPI tiles, sidebar navigation, and tabbed content panels.",
+  "intent": {
+    "triggers": ["dashboard", "analytics", "metrics", "admin panel", "overview", "data view", "home screen"],
+    "summary": "When the user asks for a dashboard or analytics view, refer to the AgnosticUI Discovery Dashboard Playbook."
+  },
+  "recipe": {
+    "layout": "Sidebar navigation on the left, fixed Header across the top, main content area on the right. Main area: horizontal stats bar (3-4 metric AgCard tiles) above a tabbed content section.",
+    "components": [
+      { "component": "AgSidebar",       "role": "Persistent left-nav with icon links to app sections" },
+      { "component": "AgHeader",        "role": "Top bar with logo, breadcrumb, and user avatar" },
+      { "component": "AgCard",          "role": "Metric KPI tile in the top stats bar" },
+      { "component": "AgTabs",          "role": "Switch between content sections (Overview, Reports, Users)" },
+      { "component": "AgBadge",         "role": "Status indicator on data rows (Active, Pending, Error)" },
+      { "component": "AgAvatar",        "role": "User profile in the top-right header area" },
+      { "component": "AgSkeletonLoader","role": "Placeholder shown while async data loads" },
+      { "component": "AgButton",        "role": "Primary actions such as Export or Add New" }
+    ],
+    "notes": "Group metric cards in a horizontal flex container. Each card follows this shape:\n```json\n[\n  { \"id\": \"metric-revenue\", \"component\": \"AgCard\", \"children\": [\"metric-label\", \"metric-value\"] },\n  { \"id\": \"metric-label\",   \"component\": \"AgText\", \"text\": \"Revenue\", \"el\": \"p\" },\n  { \"id\": \"metric-value\",   \"component\": \"AgText\", \"text\": \"$12,400\", \"el\": \"h2\" }\n]\n```"
+  }
+}

--- a/v2/playbooks/form-association/sdui.json
+++ b/v2/playbooks/form-association/sdui.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "form-association",
+  "displayName": "Contact Form (FACE)",
+  "description": "Contact form demonstrating Form Associated Custom Elements (FACE): native FormData submission, form.reset(), and constraint validation with no manual JS state wiring.",
+  "intent": {
+    "triggers": ["form", "native form", "form submission", "form validation", "contact form", "FACE", "form associated custom elements"],
+    "summary": "When the user asks for a contact form, native form submission, or FACE demonstration, refer to the AgnosticUI Contact Form (FACE) Playbook."
+  },
+  "recipe": {
+    "layout": "Centered single-column form. Fields stack vertically: Full Name, Email, Phone (optional), Message textarea, Newsletter Frequency selection group, Preferred Contact Method radio group (in a fieldset), Subscribe checkbox, Terms toggle. Submit and Reset buttons at the bottom.",
+    "components": [
+      { "component": "AgInput",              "role": "Full Name, Email, Phone, and Message fields; values surface via native FormData" },
+      { "component": "AgSelectionButtonGroup","role": "Newsletter Frequency: Weekly / Monthly / Major announcements only (radio, required)" },
+      { "component": "AgRadio",              "role": "Preferred Contact Method group sharing a name attribute inside a fieldset" },
+      { "component": "AgCheckbox",           "role": "Optional newsletter subscribe opt-in" },
+      { "component": "AgToggle",             "role": "Required Terms acceptance with custom validationMessages for i18n" },
+      { "component": "AgButton",             "role": "Submit and Reset form actions at the bottom of the form" },
+      { "component": "AgDivider",            "role": "Visual separator between form sections" }
+    ],
+    "notes": "No JS state needed for field values — ag-input participates in the parent <form> natively via FACE. Terms toggle with custom error copy:\n```json\n{ \"id\": \"terms\", \"component\": \"AgToggle\", \"props\": { \"name\": \"terms\", \"required\": true, \"validationMessages\": { \"valueMissing\": \"Please accept the terms to continue.\" } } }\n```"
+  }
+}

--- a/v2/playbooks/grid/sdui.json
+++ b/v2/playbooks/grid/sdui.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "grid",
+  "displayName": "Data Grid",
+  "description": "E-commerce inventory admin screen with a segmented control to swap between three table implementations: AgnosticUI Table, Grid.js, and TanStack Table.",
+  "intent": {
+    "triggers": ["data grid", "table", "sortable list", "data table", "inventory", "admin table", "spreadsheet view"],
+    "summary": "When the user asks for a data grid, sortable table, or inventory screen, refer to the AgnosticUI Data Grid Playbook."
+  },
+  "recipe": {
+    "layout": "App shell with a fixed Header and Breadcrumb trail (Home / Inventory). Main content area: 'View as' segmented control (Simple / Grid.js / TanStack) in the top-right corner. Below it, a toolbar row with a search Input, filter Selects, and bulk-action Buttons. The active table panel fills the remaining space. Pagination row at the bottom.",
+    "components": [
+      { "component": "AgHeader",     "role": "App shell top bar with logo" },
+      { "component": "AgBreadcrumb", "role": "Home / Inventory navigation trail above the table" },
+      { "component": "AgInput",      "role": "Search box that filters table rows in real time" },
+      { "component": "AgSelect",     "role": "Category and status filter dropdowns in the toolbar" },
+      { "component": "AgCheckbox",   "role": "Per-row and select-all checkboxes for bulk actions" },
+      { "component": "AgTag",        "role": "Stock status labels (In Stock, Low, Out of Stock)" },
+      { "component": "AgPagination", "role": "Page through the product dataset" },
+      { "component": "AgDialog",     "role": "Confirmation modal for destructive bulk-delete actions" },
+      { "component": "AgEmptyState", "role": "Zero-results placeholder when filters match no rows" }
+    ],
+    "notes": "Each row's stock status maps to an AgTag variant. Example:\n```json\n{ \"id\": \"status-tag\", \"component\": \"AgTag\", \"props\": { \"label\": \"Low Stock\", \"variant\": \"warning\" } }\n```"
+  }
+}

--- a/v2/playbooks/landing/sdui.json
+++ b/v2/playbooks/landing/sdui.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "landing",
+  "displayName": "Landing / Marketing Page",
+  "description": "High-contrast marketing page with animated Lab (Fx) components, a sticky header, feature cards, testimonials, pricing tabs, and an FAQ accordion.",
+  "intent": {
+    "triggers": ["landing page", "marketing", "hero section", "homepage", "marketing page", "product page", "promotional page"],
+    "summary": "When the user asks for a landing page, marketing page, or product homepage, refer to the AgnosticUI Landing / Marketing Page Playbook."
+  },
+  "recipe": {
+    "layout": "Full-width vertical stack. Sticky AgHeader at top. Sections in order: Hero (large heading + animated AgButtonFx CTA), Features grid (3-column AgCards), Testimonials (AgAvatar + quotes), Pricing (AgTabs toggling monthly/annual plans), FAQ (AgAccordion), Footer. AgSkinSwitcher FAB fixed bottom-right for live theme switching.",
+    "components": [
+      { "component": "AgHeader",      "role": "Sticky navigation bar with logo and primary CTA" },
+      { "component": "AgButtonFx",    "role": "Animated primary call-to-action in the hero section" },
+      { "component": "AgBadgeFx",     "role": "Animated 'New' or promotional label above the hero headline" },
+      { "component": "AgIconButtonFx","role": "Animated icon actions in the feature highlight section" },
+      { "component": "AgCard",        "role": "Feature highlight tile in the three-column features grid" },
+      { "component": "AgAvatar",      "role": "Testimonial author portrait beside the quote" },
+      { "component": "AgTabs",        "role": "Toggle between monthly and annual pricing plans" },
+      { "component": "AgAccordion",   "role": "Expand/collapse individual FAQ items" }
+    ],
+    "notes": "Fx components accept the same props as their base counterparts plus an 'fx' animation variant. Hero CTA example:\n```json\n{ \"id\": \"hero-cta\", \"component\": \"AgButtonFx\", \"props\": { \"fx\": \"zoom\", \"label\": \"Get started free\", \"variant\": \"primary\" } }\n```"
+  }
+}

--- a/v2/playbooks/login/sdui.json
+++ b/v2/playbooks/login/sdui.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "login",
+  "displayName": "Login Form",
+  "description": "Centered authentication form with social login buttons, email/password inputs, and a remember-me checkbox on a full-bleed background image.",
+  "intent": {
+    "triggers": ["login", "sign in", "authentication", "auth form", "user login", "sign up"],
+    "summary": "When the user asks for a login or sign-in page, refer to the AgnosticUI Login Form Playbook."
+  },
+  "recipe": {
+    "layout": "Full-bleed background image. AgCard centered vertically and horizontally holds the logo, social login buttons, a labeled divider, email and password inputs, a remember-me checkbox, the primary submit button, and a forgot-password link.",
+    "components": [
+      { "component": "AgCard",     "role": "Floating panel that groups all form controls" },
+      { "component": "AgButton",   "role": "Social login (Google, Facebook) and primary submit action" },
+      { "component": "AgInput",    "role": "Email address and password credential fields" },
+      { "component": "AgCheckbox", "role": "Remember me opt-in below the password field" },
+      { "component": "AgDivider",  "role": "Visual separator between social and credential sections" },
+      { "component": "AgImage",    "role": "Full-bleed background and in-card logo" },
+      { "component": "AgLink",     "role": "Forgot password and create account navigation links" }
+    ],
+    "notes": "Social buttons come first, then a labeled AgDivider, then credential inputs. Example AgNode for the password field:\n```json\n{ \"id\": \"pwd\", \"component\": \"AgInput\", \"props\": { \"type\": \"password\", \"label\": \"Password\", \"name\": \"password\", \"required\": true } }\n```"
+  }
+}

--- a/v2/playbooks/onboarding/sdui.json
+++ b/v2/playbooks/onboarding/sdui.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "onboarding",
+  "displayName": "Onboarding Wizard",
+  "description": "Multi-step wizard that guides a new user through path selection, interest choices, and a review screen before launching the app.",
+  "intent": {
+    "triggers": ["onboarding", "wizard", "multi-step", "getting started", "user setup", "setup flow", "step wizard"],
+    "summary": "When the user asks for an onboarding wizard or multi-step setup flow, refer to the AgnosticUI Onboarding Wizard Playbook."
+  },
+  "recipe": {
+    "layout": "Full-viewport single-page app. AgProgress indicator at the top tracks the current step. Center content area renders one step at a time. Persistent Back/Next navigation row at the bottom (the interstitial step replaces it with a top Back link and full-width Next button).",
+    "components": [
+      { "component": "AgProgress",            "role": "Step indicator showing how far through the wizard the user is" },
+      { "component": "AgSelectionCardGroup",  "role": "Card-grid for path selection and interest multi-select steps" },
+      { "component": "AgSelectionButtonGroup","role": "Pill-button group for single-select choices (e.g. framework preference)" },
+      { "component": "AgButton",              "role": "Back, Next, and final submit actions" },
+      { "component": "AgAlert",               "role": "Confirmation message on the review and completion step" },
+      { "component": "AgIcon",                "role": "Decorative icons inside selection cards" }
+    ],
+    "notes": "Each step is a separate component rendered conditionally by a step index. Example AgNode for the path-selection step:\n```json\n{ \"id\": \"path-group\", \"component\": \"AgSelectionCardGroup\", \"props\": { \"multiple\": false }, \"children\": [\"card-frontend\", \"card-backend\", \"card-fullstack\"] }\n```"
+  }
+}

--- a/v2/playbooks/support/sdui.json
+++ b/v2/playbooks/support/sdui.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../playbook-sdui.schema.json",
+  "version": 1,
+  "slug": "support",
+  "displayName": "Support Center",
+  "description": "Tabbed support hub with live chat, knowledge base search, ticket submission, and account settings.",
+  "intent": {
+    "triggers": ["support", "help center", "knowledge base", "FAQ", "tickets", "live chat", "customer support", "help desk"],
+    "summary": "When the user asks for a support center, help desk, or customer service portal, refer to the AgnosticUI Support Center Playbook."
+  },
+  "recipe": {
+    "layout": "Full-width page with a fixed Header. Main content is a four-tab layout: Live Chat, Knowledge Base, Submit a Ticket, and Settings. Each tab fills the remaining viewport height.",
+    "components": [
+      { "component": "AgTabs",          "role": "Top-level navigation between the four support sections" },
+      { "component": "AgMessageBubble", "role": "Individual chat messages in the Live Chat tab" },
+      { "component": "AgCombobox",      "role": "Search-as-you-type knowledge base article lookup" },
+      { "component": "AgDialog",        "role": "Article preview modal opened from search results" },
+      { "component": "AgDrawer",        "role": "Ticket history side panel that slides in from the edge" },
+      { "component": "AgSelect",        "role": "Category and priority dropdowns in the ticket form" },
+      { "component": "AgPagination",    "role": "Page through ticket history results" },
+      { "component": "AgRating",        "role": "Post-resolution satisfaction rating widget" },
+      { "component": "AgToggle",        "role": "Notification preference switches in the Settings tab" }
+    ],
+    "notes": "The Live Chat tab keeps AgMessageBubble items in a scrollable flex column, newest at the bottom. Example AgNode for a chat message:\n```json\n{ \"id\": \"msg-1\", \"component\": \"AgMessageBubble\", \"props\": { \"isMe\": false, \"text\": \"How can I help you today?\" } }\n```"
+  }
+}

--- a/v2/scripts/generate-playbooks-manifest.mjs
+++ b/v2/scripts/generate-playbooks-manifest.mjs
@@ -173,6 +173,11 @@ export function generateManifest() {
     if (meta.externalFiles) entry.externalFiles = meta.externalFiles;
     if (meta.contentReplacements) entry.contentReplacements = meta.contentReplacements;
 
+    // Include root-level sdui.json when present (agentic intent decoration file).
+    if (existsSync(join(PLAYBOOKS_DIR, basePath, 'sdui.json'))) {
+      entry.rootFiles = ['sdui.json'];
+    }
+
     playbooks[slug] = entry;
   }
 


### PR DESCRIPTION
Adds sdui.json to login, onboarding, dashboard, support, grid, blog,
landing, and form-association playbooks. Updates generate-playbooks-manifest.mjs
to detect root-level sdui.json and emit rootFiles in the manifest entry.
All 8 files validated against playbook-sdui.schema.json.
