### PR TITLE
Fix #480: Reimagine docs for the agentic era

### DIFF
--- a/v2/site/docs/.vitepress/theme/components/CliPreview.vue
+++ b/v2/site/docs/.vitepress/theme/components/CliPreview.vue
@@ -2,7 +2,7 @@
   <div class="cli-preview-section">
     <div class="cli-preview-container">
       <h2>Get Started in Seconds</h2>
-      <p class="subtitle">No more hallucinated UIs. One command sets you up.</p>
+      <p class="subtitle">Three commands and your agent of choice knows your entire stack.</p>
 
       <div class="cli-terminal">
         <div class="terminal-header">
@@ -27,26 +27,28 @@
           </div>
         </div>
       </div>
-      <VueLink
-        href="/installation"
+      <VueButtonFx
+        fx="press-shadow"
+        fx-ease="ease"
+        fx-speed="md"
+        variant="success"
+        shape="capsule"
+        size="lg"
         class="jumbo-button"
-        :isButton="true"
-        buttonShape="capsule"
-        buttonSize="xl"
-        variant="primary"
-        
+        @click="() => router.go('/installation')"
       >
-        View Full Installation Guide
-        <ArrowRight :size="20" style="display: inline-block; vertical-align: middle; margin-left: 0.5rem;" />
-      </VueLink>
+        Get Agent-Ready in 3 Steps →
+      </VueButtonFx>
     </div>
   </div>
 </template>
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { VueLink } from 'agnosticui-core/link/vue'
-import { ArrowRight } from 'lucide-vue-next'
+import { useRouter } from 'vitepress'
+import { VueButtonFx } from 'agnosticui-core/button-fx/vue'
+
+const router = useRouter()
 
 const commands = [
   {
@@ -63,6 +65,14 @@ const commands = [
       '✓ Adding button component...',
       '✓ Button component ready in src/components/ag/button/',
       '✨ Done! Import and use your button component.'
+    ]
+  },
+  {
+    command: 'npx agnosticui-cli context',
+    output: [
+      '✓ Detected Claude Code — writing to CLAUDE.md',
+      '✓ 7 components · 2 playbooks included',
+      'Done! Prompt Claude, Copilot, Gemini, or Codex — they know your stack.'
     ]
   }
 ]

--- a/v2/site/docs/index.md
+++ b/v2/site/docs/index.md
@@ -5,7 +5,10 @@ layout: home
 hero:
   name: "AgnosticUI Local"
   text: "The AI-native UI kit"
-  tagline: Lives in your codebase so AI can actually help. React. Vue. Lit. Svelte. Solid. And more.
+  tagline: >
+    Local source lives in your codebase. Our AG Context Generator arms your
+    favorite LLM with exact component locations, types, and usage.
+    Claude. Codex. Copilot. Gemini. And more.
 ---
 
 <script setup>
@@ -45,15 +48,15 @@ onUnmounted(() => {
 <div class="custom-features">
   <div class="custom-feature">
     <h3>Local Components</h3>
-    <p>The entire UI library lives in your project—no MCP setup, node_modules, or npm. Every component AI-readable and yours to customize.</p>
+    <p>The entire UI library lives in your project (React, Vue, Lit, Svelte, Solid, and more). No MCP setup, node_modules, or npm. Every component is AI-readable.</p>
+  </div>
+  <div class="custom-feature">
+    <h3>Arm Your Agent</h3>
+    <p>Run <code>ag context</code> once and any AI coding assistant (Claude, Copilot, Cursor, Windsurf, Gemini) gets your exact prop types, import paths, and playbook blueprints. No hallucinated APIs.</p>
   </div>
   <div class="custom-feature">
     <h3>AI Can Actually Help</h3>
-    <p>No opaque npm packages. No wasted tokens on documentation. No context limits. No hallucinated APIs. Just instant, accurate help.</p>
-  </div>
-  <div class="custom-feature">
-    <h3>Smooth Migration Path</h3>
-    <p>Already using Shadcn, MUI, or Chakra? Migrate components one at a time. Works with React, Vue, Lit, and Svelte—your timeline, your rules.</p>
+    <p>No opaque npm packages. No wasted tokens on documentation. No context limits. Just accurate, instant help every session.</p>
   </div>
 </div>
 
@@ -64,7 +67,7 @@ onUnmounted(() => {
     fx-speed="xl"
     variant="primary"
     shape="capsule"
-    size="xl"
+    size="lg"
     class="jumbo-button"
     @click="() => router.go('/components/button')"
   >
@@ -75,11 +78,11 @@ onUnmounted(() => {
     fx-speed="xl"
     variant="monochrome"
     shape="capsule"
-    size="xl"
+    size="lg"
     class="jumbo-button"
     @click="() => router.go('/playbooks/')"
   >
-    View Playbooks →
+    View Agentic Playbooks →
   </VueButtonFx>
 </div>
 

--- a/v2/site/docs/installation.md
+++ b/v2/site/docs/installation.md
@@ -6,9 +6,63 @@
 import AlphaWarning from './components/AlphaWarning.vue';
 </script>
 
-AgnosticUI can be installed in two ways: using the **AgnosticUI CLI** (recommended) or as an **npm package**. Choose the approach that best fits your workflow.
+AgnosticUI is designed around a single principle: **your AI agent should know your UI stack as well as you do.** The CLI copies components directly into your project so every prop type, import path, and layout blueprint is readable source code — not a locked npm package. One command arms any agent (Claude, Gemini, Cursor, Windsurf, Codex) with everything it needs to generate production-grade UI without guessing.
+
+There are two installation paths: the **CLI** (recommended, agent-ready) and the **npm package** (for teams who prefer dependency management). Both converge at Step 3: `ag context`.
+
+## The 3-Step Agentic Path
+
+> For teams who want the fastest route from zero to an AI agent that knows your entire UI stack.
+
+**Step 1 — Init:** Scaffold your framework and copy components into your project.
+
+```shell
+npx agnosticui-cli init
+npx agnosticui-cli add button card input
+```
+
+**Step 2 — (Optional) Install Playbooks:** Add machine-readable UI blueprints for common patterns.
+
+```shell
+npx agnosticui-cli playbook dashboard --framework react
+npx agnosticui-cli playbook login --framework react
+```
+
+**Step 3 — Context:** Generate the Agentic Intent context file for your AI tool.
+
+```shell
+npx agnosticui-cli context
+```
+
+Expected output:
+
+```shell
+◆  AgnosticUI Context Generator
+   Detected Claude Code — writing to CLAUDE.md
+   Detected 2 playbooks: dashboard, login. Schemas included.
+
+✓  Context written to CLAUDE.md
+   Components:  7
+   Framework:   react
+   Playbooks:   2  (dashboard, login)
+
+   AI coding tools (Claude Code, Cursor, Windsurf) will now
+   automatically know about your installed components.
+
+   Re-run after adding components: npx agnosticui-cli context
+```
+
+**Orchestrate:** Open your agent of choice and prompt naturally.
+
+> "Build me a dashboard page" → agent consults the AgnosticUI Discovery Dashboard Intent Schema → returns idiomatic, source-correct React code using the right components and layout.
+
+The context file is the **Instruction Set** that makes any LLM an AgnosticUI-expert — once, not every session.
 
 ## AgnosticUI CLI (Recommended)
+
+::: info
+This section covers the same steps as the 3-Step Agentic Path above in greater detail. Some overlap is intentional.
+:::
 
 The AgnosticUI CLI provides a "local-first" approach where components are copied directly into your project. This gives you full ownership and control over the component code, making it easy to customize and extend components without worrying about breaking changes from upstream updates.
 
@@ -137,23 +191,29 @@ You can view the full list of theme tokens available in <a href="https://github.
    </script>
    ```
 
-3. **Add Components**
+3. **Arm Your Agent**
+
+   Generate the Agentic Intent context file so any AI coding assistant knows your
+   installed components, their prop types, import paths, and — if you have installed
+   playbooks — their structural layout recipes:
+
+   ```bash
+   npx agnosticui-cli context
+   ```
+
+   AgnosticUI auto-detects which agent you're using (Claude Code, Cursor, Copilot,
+   Windsurf, Gemini, Codex) and writes to the right file. If playbooks are installed,
+   their Intent Schemas are injected automatically — no flag needed.
+
+   > Re-run after adding components or playbooks to keep the context current.
+
+4. **Add Components**
 
    Use the CLI to add the components you need:
 
    ```bash
    npx agnosticui-cli add button input card
    ```
-
-4. **Wire Up Your AI Coding Assistant**
-
-   Generate a context file so tools like Claude Code, Cursor, or Copilot know your installed components, their prop types, and import paths:
-
-   ```bash
-   npx agnosticui-cli context
-   ```
-
-   AgnosticUI auto-detects which AI tool you're using and writes to the right file. Re-run after adding more components to keep context current. See the [Generating AI Context](#generating-ai-context) section below for `--format` and `--output` options.
 
 5. **Use Components**
 
@@ -445,7 +505,7 @@ npm run dev
 
 Or copy only the pieces you need into your own project.
 
-### Generating AI Context
+### Agentic Intent: Arming Your AI Agent
 
 Once you have components installed, generate an AI context file so your coding assistant knows their prop types and import paths:
 
@@ -456,6 +516,33 @@ npx agnosticui-cli context
 AgnosticUI auto-detects configured tools (Claude Code, Cursor, Copilot, Windsurf, and others) and writes a formatted context block to the appropriate file. If multiple tools are detected, it prompts you to choose.
 
 Re-running the command after adding more components splices the updated content in place — it never duplicates or overwrites unrelated content.
+
+#### Playbook Intent Schemas (automatic)
+
+If you have installed any playbooks, `ag context` automatically detects them and injects
+their **Intent Schemas** into the context file — no extra flag required:
+
+```shell
+Detected 2 installed playbooks (dashboard, login) — including Intent Schemas.
+```
+
+The generated context file gains an **AgnosticUI Agentic Intent** section that tells your
+agent which playbook to use and how to compose it when a user expresses a UI intent:
+
+```markdown
+## AgnosticUI Agentic Intent — Playbook Recipes
+
+When the user asks for a **dashboard**, **analytics view**, or **admin panel**,
+refer to the AgnosticUI Discovery Dashboard Playbook:
+- Use `ag-card` for metric KPI tiles in the top stats bar
+- Use `ag-avatar` for user profile in the top-right header
+- Use `ag-tabs` to switch between content sections (Overview, Reports, Users)
+- Use `ag-badge` for status indicators on data rows
+- Layout: sidebar nav + main content area, metric cards in a horizontal flex row at top
+```
+
+This is the **Instruction Set** model: instead of prompting "build me a dashboard" and
+hoping the AI guesses correctly, the agent follows a deterministic recipe.
 
 Use `--format` to target a specific tool explicitly:
 

--- a/v2/site/docs/playbooks/index.md
+++ b/v2/site/docs/playbooks/index.md
@@ -6,6 +6,11 @@ import PlaybooksGrid from '../components/PlaybooksGrid.vue'
 
 UI patterns built with AgnosticUI, available in React, Vue, and Lit.
 
+> **[Agent-Ready] Playbooks** include machine-readable Intent Schemas. Run
+> `npx agnosticui-cli context` after installing a playbook and your AI agent
+> automatically receives its structural recipe — component roles, layout hints,
+> and trigger phrases it can match against user prompts.
+
 > **Theme Playground:** Use the palette button in the bottom-right corner to pick a skin, extract a theme from an image, or paste custom CSS vars. Your theme persists as you navigate between playbooks.
 
 ## Playbooks


### PR DESCRIPTION
# Fixes #480: Reimagine docs for the agentic era
                                                                                                                                                                                                           
  Summary:                                                            
                                                                                                                                                                                                           
  - Updates the index.md hero tagline to lead with the "Our AG Context Generator" value proposition, naming Claude, Codex, Copilot, and Gemini explicitly                                                  
  - Replaces the three feature cards with a tighter set: Local Components, Arm Your Agent (ag context focused), and AI Can Actually Help                                                                   
  - Swaps the CliPreview subtitle and adds npx agnosticui-cli context as the third animated terminal command, with a VueButtonFx press-shadow CTA replacing the plain link                                 
  - Renames "Generating AI Context" to "Agentic Intent: Arming Your AI Agent" and adds a Playbook Intent Schemas callout block                                                                             
  - Adds a "3-Step Agentic Path" section at the top of installation.md as a fast-path overview, with an info callout on the detailed section below noting the intentional overlap                          
  - Reorders Quick Start steps so ag context comes before add components                                                                                                                                   
  - Updates playbooks/index.md with Agent-Ready framing paragraph                                                                                                                                          
                                                                                                                                                                                                           
  Dependencies: #477, #478, #479 should be merged before playbook-card badges are meaningful, but these structural changes are safe to land independently. 