### PR TITLE
Fixes #495 — SelectionCardGroup/SelectionButtonGroup not updating when controlled values cleared

### DIFF
--- a/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.spec.ts
+++ b/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { AgSelectionCardGroup } from './SelectionCardGroup';
+import { AgSelectionCardGroup, type SelectionCardGroupTheme } from './SelectionCardGroup';
 import { AgSelectionCard } from '../../SelectionCard/core/SelectionCard';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -208,6 +208,38 @@ describe('SelectionCardGroup - Comprehensive Tests', () => {
       expect((cards[1] as AgSelectionCard).checked).toBe(false);
       expect((cards[2] as AgSelectionCard).checked).toBe(true);
     });
+    it('should clear all selections when controlled values prop changes to empty array', async () => {
+      const group = await createGroup({ type: 'checkbox', values: ['a', 'c'] });
+      await group.updateComplete;
+
+      let cards = group.querySelectorAll('ag-selection-card');
+      expect((cards[0] as AgSelectionCard).checked).toBe(true);
+      expect((cards[2] as AgSelectionCard).checked).toBe(true);
+
+      group.values = [];
+      await group.updateComplete;
+
+      cards = group.querySelectorAll('ag-selection-card');
+      expect((cards[0] as AgSelectionCard).checked).toBe(false);
+      expect((cards[1] as AgSelectionCard).checked).toBe(false);
+      expect((cards[2] as AgSelectionCard).checked).toBe(false);
+    });
+
+    it('should clear selection when controlled radio value prop changes to empty string', async () => {
+      const group = await createGroup({ type: 'radio', value: 'b' });
+      await group.updateComplete;
+
+      let cards = group.querySelectorAll('ag-selection-card');
+      expect((cards[1] as AgSelectionCard).checked).toBe(true);
+
+      group.value = '';
+      await group.updateComplete;
+
+      cards = group.querySelectorAll('ag-selection-card');
+      cards.forEach((card) => {
+        expect((card as AgSelectionCard).checked).toBe(false);
+      });
+    });
   });
 
   describe('Disabled State', () => {
@@ -347,6 +379,21 @@ describe('SelectionCardGroup - Comprehensive Tests', () => {
     it('should use custom validationMessage when validationMessages.valueMissing is set', async () => {
       const group = await createGroup({ required: true, validationMessages: { valueMissing: 'Custom message' } }, []);
       expect(group.validationMessage).toBe('Custom message');
+    });
+  });
+
+  describe('Themes', () => {
+    const themes: SelectionCardGroupTheme[] = ['', 'success', 'info', 'warning', 'error', 'monochrome'];
+
+    themes.forEach((theme) => {
+      it(`should apply theme="${theme || 'default'}" to all cards`, async () => {
+        const group = await createGroup({ theme });
+        const cards = group.querySelectorAll('ag-selection-card');
+
+        cards.forEach((card) => {
+          expect((card as AgSelectionCard)._theme).toBe(theme);
+        });
+      });
     });
   });
 });

--- a/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
+++ b/v2/lib/src/components/SelectionCardGroup/core/_SelectionCardGroup.ts
@@ -107,10 +107,10 @@ export class AgSelectionCardGroup extends FaceMixin(LitElement) implements Selec
   declare theme: SelectionCardGroupTheme;
 
   @property({ type: String })
-  declare value: string;
+  declare value: string | undefined;
 
   @property({ type: Array })
-  declare values: string[];
+  declare values: string[] | undefined;
 
   @property({ type: Boolean, reflect: true })
   declare disabled: boolean;
@@ -134,8 +134,8 @@ export class AgSelectionCardGroup extends FaceMixin(LitElement) implements Selec
     this.legend = '';
     this.legendHidden = false;
     this.theme = '';
-    this.value = '';
-    this.values = [];
+    this.value = undefined;
+    this.values = undefined;
     this.disabled = false;
     this.required = false;
     this._internalSelectedValues = [];
@@ -145,14 +145,12 @@ export class AgSelectionCardGroup extends FaceMixin(LitElement) implements Selec
   // Get current selected values (controlled or uncontrolled)
   private _getSelectedValues(): string[] {
     if (this.type === 'radio') {
-      // For radio: use controlled value if set, otherwise internal state
-      if (this.value) {
-        return [this.value];
+      if (this.value !== undefined) {
+        return this.value ? [this.value] : [];
       }
       return this._internalSelectedValues;
     }
-    // For checkbox: use controlled values if set (non-empty), otherwise internal state
-    if (this.values && this.values.length > 0) {
+    if (this.values !== undefined) {
       return this.values;
     }
     return this._internalSelectedValues;

--- a/v2/lib/src/components/SelectionCardGroup/vue/VueSelectionCardGroup.vue
+++ b/v2/lib/src/components/SelectionCardGroup/vue/VueSelectionCardGroup.vue
@@ -46,8 +46,7 @@ withDefaults(defineProps<VueSelectionCardGroupProps>(), {
   name: '',
   legend: '',
   legendHidden: false,
-  value: '',
-  values: () => [],
+  // value and values intentionally omitted — undefined signals uncontrolled mode
   disabled: false,
   required: false,
 });

--- a/v2/site/docs/examples/SelectionCardGroupExamples.vue
+++ b/v2/site/docs/examples/SelectionCardGroupExamples.vue
@@ -65,6 +65,34 @@
       </VueSelectionCard>
     </VueSelectionCardGroup>
 
+    <!-- Checkbox Group - Bugfix-style regression check, see issue #493 -->
+    <div class="mbe4">
+      <h2>Checkbox Group — Controlled Clear</h2>
+      <p class="mbs2 mbe3">Demonstrates clearing a controlled selection externally via <code>v-model:values</code></p>
+    </div>
+    <VueSelectionCardGroup
+      v-model:values="activeCardFilter"
+      type="checkbox"
+      name="card-filter"
+      legend="Select features to enable"
+      legend-hidden
+      class="mbe4"
+    >
+      <VueSelectionCard value="analytics" label="Analytics">
+        <div style="padding: 1rem; text-align: center;">Analytics</div>
+      </VueSelectionCard>
+      <VueSelectionCard value="notifications" label="Notifications">
+        <div style="padding: 1rem; text-align: center;">Notifications</div>
+      </VueSelectionCard>
+      <VueSelectionCard value="export" label="Export">
+        <div style="padding: 1rem; text-align: center;">Export</div>
+      </VueSelectionCard>
+    </VueSelectionCardGroup>
+    <p class="selection-output">
+      <VueButton class="mie3" shape="rounded" @click="handleClearCardFilterClick">Clear</VueButton>
+      Selected: {{ activeCardFilter.join(', ') || 'None' }}
+    </p>
+
     <div class="mbe4">
       <h2>Theme Variants</h2>
       <p class="mbs2 mbe3">Different color themes for various contexts</p>
@@ -239,15 +267,24 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, ref } from "vue";
 import { VueSelectionCardGroup } from "agnosticui-core/selection-card-group/vue";
 import { VueSelectionCard } from "agnosticui-core/selection-card/vue";
+import { VueButton } from "agnosticui-core/button/vue";
 
 export default defineComponent({
   name: "SelectionCardGroupExamples",
   components: {
     VueSelectionCardGroup,
     VueSelectionCard,
+    VueButton,
+  },
+  setup() {
+    const activeCardFilter = ref<string[]>([]);
+    const handleClearCardFilterClick = () => {
+      activeCardFilter.value = [];
+    };
+    return { activeCardFilter, handleClearCardFilterClick };
   },
   methods: {
     handleChange(detail: { value: string; checked: boolean; selectedValues: string[] }) {

--- a/v2/site/package-lock.json
+++ b/v2/site/package-lock.json
@@ -1980,7 +1980,7 @@
     "node_modules/agnosticui-core": {
       "version": "2.0.0-alpha.30",
       "resolved": "file:../lib/agnosticui-core-2.0.0-alpha.30.tgz",
-      "integrity": "sha512-Gk7ZCstaODENp34u7dK7+G+m3LvCq6kWpCqm+8I6V0X2/YF7E5egPwcsPP18MJsLrSDseoMyXYotNpgGYuJ7Ug==",
+      "integrity": "sha512-6sQOQLYRT4Zfz7AEb/fA64inla6/Mv+FG09nYyvZzyqQNoiE1Hz2a3jeN3U+KIuhZ9imBc52iyoBrGdAlFT7Sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",


### PR DESCRIPTION
## Fixes #495 — SelectionCardGroup/SelectionButtonGroup not updating when controlled values cleared

### Root cause

`_getSelectedValues()` in both `AgSelectionButtonGroup` and
`AgSelectionCardGroup` used falsy checks to decide between controlled
and uncontrolled mode:

- Radio: `if (this.value)` — empty string fell through to stale internal state
- Checkbox: `if (this.values && this.values.length > 0)` — empty array fell through to stale internal state

So when a consumer cleared a controlled selection (e.g. `activeFilter.value = []`),
the group ignored it and kept rendering the old selections.

### Fix

Use `undefined` as the sole uncontrolled sentinel in both group components:

- Constructor defaults changed from `''`/`[]` to `undefined`
- `_getSelectedValues()` now checks `!== undefined` instead of truthiness/length
- `@property` declarations updated to `string | undefined` / `string[] | undefined`
- Vue wrappers (`VueSelectionButtonGroup`, `VueSelectionCardGroup`): removed
  `value`/`values` from `withDefaults` so `undefined` reaches the web component
  when unbound, and restored both to the props interface as optional

### Rule: "uncontrolled = prop omitted entirely; controlled = prop bound, including to empty/falsy values"

### Also included

- Regression tests for both group components: controlled `values` cleared
  to `[]`, controlled `value` cleared to `''`
- Theme coverage tests for `SelectionCardGroup` (mirroring existing
  button group coverage)
- Docs examples: "Checkbox Group — Controlled Clear" added to both
  SelectionButtonGroup and SelectionCardGroup pages, with a working
  Clear button that exercises the fixed code path

### Testing

- SelectionButtonGroup: 45/45 passing
- SelectionCardGroup: 34/34 passing